### PR TITLE
Fix 3D edge graph pruning by projection

### DIFF
--- a/Edge_Reconst/definitions.h
+++ b/Edge_Reconst/definitions.h
@@ -10,6 +10,12 @@
 //> Print out in terminal
 #define SHOW_EDGE_SKETCH_SETTINGS     (false)
 
+//> Edge graph pruning parameters
+#define PRUNE_3D_EDGE_GRAPH_LAMBDA1     (0.5)
+#define PRUNE_3D_EDGE_GRAPH_LAMBDA2     (0.5)
+#define PRUNE_BY_PROJ_PROX_THRESH       (6)     //> in pixels
+#define PRUNE_BY_PROJ_ORIE_THRESH       (30)    //> in degrees
+
 //> Debugging purpose
 #define DEBUG                      (0)
 #define DEBUG_READ_FILES           (false)

--- a/Edge_Reconst/edge_mapping.hpp
+++ b/Edge_Reconst/edge_mapping.hpp
@@ -168,8 +168,7 @@ public:
                        HashEigenVector3dPair, FuzzyVector3dPairEqual>
     pruneEdgeGraph_by_3DProximityAndOrientation(
         std::unordered_map<std::pair<Eigen::Vector3d, Eigen::Vector3d>, int, 
-                           HashEigenVector3dPair, FuzzyVector3dPairEqual>& graph,
-        double lambda1, double lambda2);
+                           HashEigenVector3dPair, FuzzyVector3dPairEqual>& graph );
 
     using EdgeNodeList = std::vector<std::unique_ptr<EdgeNode>>;
 


### PR DESCRIPTION
3D edge graph is further pruned by projecting 3D edge links to all images and rule out links by both proximity and orientation thresholds. Also for the thresholds of scaling standard deviation for pruning 3D edge graph in the representation space, make them as macros specified in the definitions.h file.