### PR TITLE
Fix the issue when parallel edges orientations are opposite

### DIFF
--- a/Edge_Reconst/edge_mapping.hpp
+++ b/Edge_Reconst/edge_mapping.hpp
@@ -171,7 +171,7 @@ public:
     EdgeNodeList buildEdgeNodeGraph(const std::unordered_map<std::pair<Eigen::Vector3d, Eigen::Vector3d>, int,
                                 HashEigenVector3dPair, FuzzyVector3dPairEqual>& pruned_graph);
 
-    void smooth3DEdgesUsingEdgeNodes(EdgeNodeList& edge_nodes, int iterations);
+    void align3DEdgesUsingEdgeNodes(EdgeNodeList& edge_nodes, int iterations, double step_size);
 
     std::unordered_map<std::pair<Eigen::Vector3d, Eigen::Vector3d>, int, 
                    HashEigenVector3dPair, FuzzyVector3dPairEqual>

--- a/Edge_Reconst/util.cpp
+++ b/Edge_Reconst/util.cpp
@@ -134,19 +134,45 @@ namespace MultiviewGeometryUtil {
         return proj_point;
     }
 
+    // MARK: get shortest aligne
+    Eigen::Vector3d multiview_geometry_util::getShortestAlignEulerAnglesDegrees(Eigen::Vector3d v1, Eigen::Vector3d v2) {
+
+        //> first check if v1 and v2 are in opposite directions
+        Eigen::Vector3d eulerAnglesXYZ_v1_to_v2 = getAlignEulerAnglesDegrees(v1, v2);
+        Eigen::Vector3d eulerAnglesXYZ_v2_to_v1 = getAlignEulerAnglesDegrees(v2, v1);
+
+        if ( b_angles_are_large_degrees(eulerAnglesXYZ_v1_to_v2) && b_angles_are_large_degrees(eulerAnglesXYZ_v2_to_v1) ) {
+            Eigen::Vector3d v2_rev = -v2;
+            Eigen::Vector3d eulerAnglesXYZ_v1_to_v2_rev = getAlignEulerAnglesDegrees(v1, v2_rev);
+            //> check if the rotation gives the minimal path to align two vectors
+            if ( b_angles_are_large_degrees(eulerAnglesXYZ_v1_to_v2_rev) ) {
+                Eigen::Vector3d eulerAnglesXYZ_v2_rev_to_v1 = getAlignEulerAnglesDegrees(v2_rev, v1);
+                eulerAnglesXYZ_v2_rev_to_v1 *= -1;
+                return eulerAnglesXYZ_v2_rev_to_v1;
+            }
+            else
+                return eulerAnglesXYZ_v1_to_v2_rev;
+        }
+        else {
+            //> check if the rotation gives the minimal path to align two vectors
+            if ( b_angles_are_large_degrees(eulerAnglesXYZ_v1_to_v2) ) {
+                eulerAnglesXYZ_v2_to_v1 *= -1;
+                return eulerAnglesXYZ_v2_to_v1;
+            }
+            else
+                return eulerAnglesXYZ_v1_to_v2;
+        }
+    }
+
+    bool multiview_geometry_util::b_angles_are_large_degrees(Eigen::Vector3d euler_angles) {
+        return (euler_angles(0) < -90 || euler_angles(0) > 90 || euler_angles(1) < -90 || euler_angles(1) > 90 || euler_angles(2) < -90 || euler_angles(2) > 90);
+    }
+
     Eigen::Vector3d multiview_geometry_util::getAlignEulerAnglesDegrees(Eigen::Vector3d v1, Eigen::Vector3d v2) {
         Eigen::Matrix3d R_align_v1_to_v2 = getRodriguesRotationMatrix(v1, v2);
-        Eigen::Vector3d eulerAnglesXYZ = R_align_v1_to_v2.eulerAngles(0, 1, 2);
-        eulerAnglesXYZ = eulerAnglesXYZ * (180.0 / M_PI);
-        if (eulerAnglesXYZ(0) < -90 || eulerAnglesXYZ(0) > 90 || eulerAnglesXYZ(1) < -90 || eulerAnglesXYZ(1) > 90 || eulerAnglesXYZ(2) < -90 || eulerAnglesXYZ(2) > 90) {
-            Eigen::Matrix3d R_align_v2_to_v1 = getRodriguesRotationMatrix(v2, v1);
-            eulerAnglesXYZ = R_align_v2_to_v1.eulerAngles(0, 1, 2);
-            eulerAnglesXYZ = eulerAnglesXYZ * (180.0 / M_PI);
-            eulerAnglesXYZ *= -1;
-            return eulerAnglesXYZ;
-        }
-        else
-            return eulerAnglesXYZ;
+        Eigen::Vector3d eulerAnglesXYZ_v1_to_v2 = R_align_v1_to_v2.eulerAngles(0, 1, 2);
+        eulerAnglesXYZ_v1_to_v2 = eulerAnglesXYZ_v1_to_v2 * (180.0 / M_PI);
+        return eulerAnglesXYZ_v1_to_v2;
     }
 
     Eigen::Matrix3d multiview_geometry_util::getRodriguesRotationMatrix(Eigen::Vector3d v1, Eigen::Vector3d v2) {

--- a/Edge_Reconst/util.hpp
+++ b/Edge_Reconst/util.hpp
@@ -42,6 +42,8 @@ namespace MultiviewGeometryUtil {
         Eigen::Vector3d getNormalizedProjectedPoint(Eigen::Vector3d proj_point);
         Eigen::Matrix3d getRodriguesRotationMatrix(Eigen::Vector3d v1, Eigen::Vector3d v2);
         Eigen::Matrix3d euler_to_rotation_matrix(double roll, double pitch, double yaw);
+        Eigen::Vector3d getShortestAlignEulerAnglesDegrees(Eigen::Vector3d v1, Eigen::Vector3d v2);
+        bool b_angles_are_large_degrees(Eigen::Vector3d euler_angles);
         Eigen::Vector3d getAlignEulerAnglesDegrees(Eigen::Vector3d v1, Eigen::Vector3d v2);
 
         Eigen::Vector3d findClosestVectorFromPointToLine(Eigen::Vector3d P1, Eigen::Vector3d d1, Eigen::Vector3d P2);

--- a/visualization/plotEdgeIterationForces.m
+++ b/visualization/plotEdgeIterationForces.m
@@ -1,0 +1,148 @@
+function plotEdgeIterationForces(iteration)
+    % Function to plot edge location, orientation, and forces for a specific iteration
+    % Input: iteration - the iteration number to plot (0-indexed)
+    
+    %> Define the folder path containing the 3D edge output files
+    data_folder_name = 'outputs';
+    data_folder_path = fullfile(fileparts(mfilename('fullpath')), '..', data_folder_name);
+    
+    % Load the data files
+    before_alignment_path = fullfile(data_folder_path, "test_3D_edges_before_smoothing.txt");
+    after_alignment_path = fullfile(data_folder_path, "test_3D_edges_after_smoothing.txt");
+    forces_path = fullfile(data_folder_path, "test_3D_edges_total_forces.txt");
+    
+    before_alignment = importdata(before_alignment_path);
+    after_alignment = importdata(after_alignment_path);
+    
+    % Calculate number of points and verify iteration is valid
+    num_of_points = size(before_alignment, 1);
+    num_of_iters = size(after_alignment, 1) / num_of_points;
+    
+    if iteration < 0 || iteration >= num_of_iters
+        error('Iteration number out of range. Valid range: 0 to %d', num_of_iters-1);
+    end
+    
+    % Load force data
+    force_vectors = [];
+    if exist(forces_path, 'file')
+        % Open the file and read all content
+        force_content = fileread(forces_path);
+        % Split by new line to get each iteration
+        force_lines = regexp(force_content, '\n', 'split');
+        
+        % Check if we have enough iterations
+        if iteration < length(force_lines)
+            force_line = force_lines{iteration+1}; % +1 because iteration is 0-indexed
+            
+            % Parse the line by semicolons
+            force_parts = regexp(force_line, ';', 'split');
+            
+            force_vectors = zeros(length(force_parts), 3);
+            
+            for i = 1:length(force_parts)
+                if ~isempty(strtrim(force_parts{i}))
+                    % Parse the force components
+                    force_str = strtrim(force_parts{i});
+                    components = sscanf(force_str, '%f %f %f');
+                    
+                    if length(components) == 3
+                        force_vectors(i,:) = components';
+                    end
+                end
+            end
+        else
+            warning('Force data for iteration %d not found', iteration);
+        end
+    else
+        % warning('Force file not found: %s', forces_path);
+    end
+    
+    % Define color coding for points
+    color_code = [
+        1.0 0.0 0.0;    % red
+        0.0 0.0 1.0;    % blue
+        0.0 0.8 0.0;    % green
+        0.0 1.0 1.0;    % cyan
+        1.0 0.0 1.0;    % magenta
+        1.0 1.0 0.0;    % yellow
+        0.0 0.0 0.0;    % black
+        1.0 0.5 0.0;    % orange
+        0.5 0.0 0.5;    % purple
+        0.0 0.5 0.0;    % dark green
+        0.5 0.5 0.0;    % olive
+        0.0 0.5 1.0;    % sky blue
+        0.7 0.3 0.3;    % brown
+        0.5 0.5 0.5     % gray
+    ];
+    
+    % Set magnitude scaling factors
+    mag_orientation = 0.001;  % for orientation vectors
+    mag_force = 0.5;        % for force vectors
+    
+    % Create figure
+    % figure;
+    
+    % Get the indices for the requested iteration
+    start_idx = iteration * num_of_points + 1;
+    
+    % Plot each point for the given iteration
+    for i = 0:num_of_points-1
+        % Get correct color index with wraparound
+        color_idx = mod(i, size(color_code, 1)) + 1;
+        
+        % Get the point index in the after_alignment array
+        point_idx = start_idx + i;
+        
+        % Get the current point location
+        point_loc = after_alignment(point_idx,1:3);
+        
+        % Get the orientation vector
+        orientation_vec = after_alignment(point_idx,4:6);
+        
+        % Plot the point location
+        plot3(point_loc(1), point_loc(2), point_loc(3), ...
+            'Color', color_code(color_idx,:), 'Marker', 'o', 'MarkerSize', 5, 'MarkerFaceColor', color_code(color_idx,:)); 
+        hold on;
+        
+        % Plot orientation vector as a line through the point
+        quiver3(point_loc(1), point_loc(2), point_loc(3), ...
+                   mag_orientation*orientation_vec(1), mag_orientation*orientation_vec(2), mag_orientation*orientation_vec(3), ...
+                   0, 'LineWidth', 1, 'Color', 'r', 'MaxHeadSize', 0.5);
+        % line([point_loc(1) + mag_orientation*orientation_vec(1), point_loc(1) - mag_orientation*orientation_vec(1)], ...
+        %      [point_loc(2) + mag_orientation*orientation_vec(2), point_loc(2) - mag_orientation*orientation_vec(2)], ...
+        %      [point_loc(3) + mag_orientation*orientation_vec(3), point_loc(3) - mag_orientation*orientation_vec(3)], ...
+        %      'Color', color_code(color_idx,:), 'LineWidth', 1); 
+        % 
+        % Plot force vector if available
+        if ~isempty(force_vectors) && i+1 <= size(force_vectors, 1)
+            force_vec = force_vectors(i+1,:);
+            
+            % Calculate start and end points for the force arrow
+            force_start = point_loc;
+            force_end = point_loc + mag_force * force_vec;
+            
+            % Plot force vector as an arrow using quiver3
+            quiver3(force_start(1), force_start(2), force_start(3), ...
+                   mag_force*force_vec(1), mag_force*force_vec(2), mag_force*force_vec(3), ...
+                   0, 'LineWidth', 1, 'Color', 'g', 'MaxHeadSize', 0.5);
+        end
+    end
+    
+    % Set plot properties
+    axis equal;
+    % title(sprintf('Edge Locations, Orientations, and Forces at Iteration %d', iteration));
+    title(sprintf('Edge Locations and Orientations at Iteration %d', iteration));
+    xlabel('X');
+    ylabel('Y');
+    zlabel('Z');
+    grid on;
+
+    
+    % Set the background color to white
+    set(gcf, 'color', 'w');
+    ax = gca;
+    ax.Clipping = "off";
+
+    
+    hold off;
+end

--- a/visualization/test_force.m
+++ b/visualization/test_force.m
@@ -1,0 +1,12 @@
+close all;clear;
+
+idx = 49;
+figure(1);
+for i = 0:idx
+    % figure(i+1);
+    plotEdgeIterationForces(i);
+    pause(0.5);
+    % if i == 0, waitforbuttonpress; end
+    % waitforbuttonpress;
+    hold off;
+end


### PR DESCRIPTION
When edge orientations are opposite but in parallel, aligning in terms of orienting the unit vectors would be problematic. This pull request resolves such an issue by first identifying such a case and reverse the neighbor edge orientation before alignment to determine the factor for rotating the source node edge.