### PR TITLE
Integrate 3D edge connectivity graph to the main edge_mapping and add evaluation scripts

### DIFF
--- a/Edge_Reconst/EdgeSketch_Core.cpp
+++ b/Edge_Reconst/EdgeSketch_Core.cpp
@@ -260,69 +260,6 @@ void EdgeSketch_Core::Run_3D_Edge_Sketch() {
                 clusters.push_back(kv.second);
             }
 
-
-            // // // ========== Sanity Check for Cluster Validity ==========
-            // for (size_t i = 0; i < clusters.size(); ++i) {
-            //     const auto& cluster_i = clusters[i];
-
-            //     // Intra-cluster distance check (> 1 pixel)
-            //     for (size_t m = 0; m < cluster_i.size(); ++m) {
-            //         for (size_t n = m + 1; n < cluster_i.size(); ++n) {
-            //             double dist = (Edges_HYPO2_final.row(cluster_i[m]).head<2>() - 
-            //                         Edges_HYPO2_final.row(cluster_i[n]).head<2>()).norm();
-            //             if (dist > 2.0) {
-            //                 std::cout << "Cluster " << i << " has intra-cluster distance > 2 pixel\n";
-            //                 for (int idx : cluster_i) {
-            //                     std::cout << "  Edge at (" << Edges_HYPO2_final(idx, 0) << ", " 
-            //                             << Edges_HYPO2_final(idx, 1) << ")\n";
-            //                 }
-            //                 exit(0);
-            //             }
-            //         }
-            //     }
-
-            //     // Inter-cluster distance check (< 2 pixels)
-            //     for (size_t j = i + 1; j < clusters.size(); ++j) {
-            //         const auto& cluster_j = clusters[j];
-            //         for (int idx_i : cluster_i) {
-            //             for (int idx_j : cluster_j) {
-            //                 double dist = (Edges_HYPO2_final.row(idx_i).head<2>() - 
-            //                             Edges_HYPO2_final.row(idx_j).head<2>()).norm();
-            //                 if (dist < 3.0) {
-            //                     std::cout << "Clusters " << i << " and " << j << " have inter-cluster distance < 2 pixels\n";
-            //                     std::cout << "  Cluster " << i << ":\n";
-            //                     for (int idx : cluster_i) {
-            //                         std::cout << "    (" << Edges_HYPO2_final(idx, 0) << ", " 
-            //                                 << Edges_HYPO2_final(idx, 1) << ")\n";
-            //                     }
-            //                     std::cout << "  Cluster " << j << ":\n";
-            //                     for (int idx : cluster_j) {
-            //                         std::cout << "    (" << Edges_HYPO2_final(idx, 0) << ", " 
-            //                                 << Edges_HYPO2_final(idx, 1) << ")\n";
-            //                     }
-            //                     exit(0);
-            //                 }
-            //             }
-            //         }
-            //     }
-            //}
-            // ========== End Sanity Check ==========
-
-
-            // if (std::abs(Edges_HYPO1(H1_edge_idx, 0) - 488.52) < 0.01 && std::abs(Edges_HYPO1(H1_edge_idx, 1) - 447.611) < 0.01) {
-            //     std::cout << "Clusters for edge H1 index " << H1_edge_idx << ":\n";
-            //     int cluster_id = 0;
-            //     for (const auto& cluster : clusters) {
-            //         std::cout << "  Cluster " << cluster_id++ << ":\n";
-            //         for (int idx : cluster) {
-            //             double x = Edges_HYPO2_final(idx, 0);
-            //             double y = Edges_HYPO2_final(idx, 1);
-            //             std::cout << "    Edge at (" << x << ", " << y << ")\n";
-            //         }
-            //     }
-            // }
-
-
             // averaging each cluster
             HYPO2_idx.resize(N, 1);
             for (const auto& cluster : clusters) {
@@ -1041,7 +978,7 @@ void EdgeSketch_Core::Stack_3D_Edges() {
     tangents_file.close();
 #endif
 
-    Eigen::MatrixXd mvt_3d_edges = NViewsTrian::mvt(hyp01_view_indx, hyp02_view_indx);
+    Eigen::MatrixXd mvt_3d_edges = NViewsTrian::mvt(hyp01_view_indx, hyp02_view_indx, Scene_Name);
 
     //> Concatenate reconstructed 3D edges
     if (all_3D_Edges.rows() == 0) {

--- a/Edge_Reconst/edge_mapping.cpp
+++ b/Edge_Reconst/edge_mapping.cpp
@@ -736,8 +736,7 @@ void EdgeMapping::writeCurvesToFile(const std::vector<Curve>& curves,
                         << node.orientation.x() << " " << node.orientation.y() << " " << node.orientation.z() << "\n";
             }
             else {
-                outfile << node.location.x() << " " << node.location.y() << " " << node.location.z() << " "
-                        << node.orientation.x() << " " << node.orientation.y() << " " << node.orientation.z() << "\n";
+                outfile << node.location.x() << " " << node.location.y() << " " << node.location.z() << "\n";
             }
         }
         

--- a/Edge_Reconst/edge_mapping.cpp
+++ b/Edge_Reconst/edge_mapping.cpp
@@ -37,9 +37,20 @@ void EdgeMapping::add3DToSupportingEdgesMapping(const Eigen::Vector3d &edge_3D,
 ///////////////////////// convert 3d->2d relationship to 2d uncorrect -> 3d /////////////////////////
 std::unordered_map<EdgeMapping::Uncorrected2DEdgeKey, std::vector<EdgeMapping::Uncorrected2DEdgeMappingData>, EdgeMapping::HashUncorrected2DEdgeKey>
 EdgeMapping::map_Uncorrected2DEdge_To_SupportingData() {
+
     std::unordered_map<Uncorrected2DEdgeKey, std::vector<Uncorrected2DEdgeMappingData>, HashUncorrected2DEdgeKey> map;
+    Eigen::Vector3d target_edge1(0.499087, -0.00374706, 0.556089);
+    Eigen::Vector3d target_edge2(0.499348, -0.00377749, 0.554009);
 
     for (const auto& [edge_3D, support_list] : edge_3D_to_supporting_edges) {
+
+        bool is_target = false;
+        // if (edge_3D.isApprox(target_edge1, 1e-6) || edge_3D.isApprox(target_edge2, 1e-6)) {
+        //     is_target = true;
+        //     std::cout << "Found target 3D edge: (" << edge_3D.x() << ", " << edge_3D.y() << ", " << edge_3D.z() << ")" << std::endl;
+        //     std::cout << "Corresponding 2D edges:" << std::endl;
+        // }
+        
         for (const auto& data : support_list) {
             Uncorrected2DEdgeKey key{
                 data.edge_uncorrected,
@@ -53,6 +64,18 @@ EdgeMapping::map_Uncorrected2DEdge_To_SupportingData() {
                 data.tangents_3D_world,
                 data.edge
             };
+
+            // if (is_target) {
+            //     std::cout << "  Uncorrected 2D edge: (" 
+            //               << data.edge_uncorrected.x() << ", " 
+            //               << data.edge_uncorrected.y() << ", " 
+            //               << data.edge_uncorrected.z() << ")" << std::endl;
+            //     std::cout << "  Corrected 2D edge: (" 
+            //               << data.edge.x() << ", " 
+            //               << data.edge.y() << ")" << std::endl;
+            //     std::cout << "  Image number: " << data.image_number << std::endl;
+            //     std::cout << "  ---------------------" << std::endl;
+            // }
 
             map[key].push_back(record);
         }
@@ -322,9 +345,9 @@ EdgeMapping::pruneEdgeGraphbyProjections(std::unordered_map<std::pair<Eigen::Vec
     // return graph;
     return pruned_graph_by_proj;
 }
-
-
 ///////////////////////// End of pruning weighted graph by projecting to all views /////////////////////
+
+
 
 ///////////////////////// build a map of 3d edges with its neighbors /////////////////////////
 EdgeMapping::EdgeNodeList EdgeMapping::buildEdgeNodeGraph(const std::unordered_map<std::pair<Eigen::Vector3d, Eigen::Vector3d>, int,
@@ -421,15 +444,15 @@ void EdgeMapping::align3DEdgesUsingEdgeNodes(EdgeNodeList& edge_nodes, int itera
     // neighbor_file.close();
     ///////////////////// find neighbor connection //////////////////////////////////
 
-    for (size_t i = 0; i < edge_nodes.size(); ++i) {
-        const auto& node = edge_nodes[i];
-        before_out << node->location.transpose() << " " << node->orientation.transpose()<<"\n";
-        if (target_indices.count(i)){
-            //before_out << node->location.transpose() << " " << node->orientation.transpose()<<"\n";
-            //std::cout << node->location.transpose()<<" "<<node->orientation.transpose()<< "; "<<std::endl;
-            std::cout << node->orientation.transpose()<<std::endl;
-        }
-    }
+    // for (size_t i = 0; i < edge_nodes.size(); ++i) {
+    //     const auto& node = edge_nodes[i];
+    //     before_out << node->location.transpose() << " " << node->orientation.transpose()<<"\n";
+    //     if (target_indices.count(i)){
+    //         //before_out << node->location.transpose() << " " << node->orientation.transpose()<<"\n";
+    //         //std::cout << node->location.transpose()<<" "<<node->orientation.transpose()<< "; "<<std::endl;
+    //         std::cout << node->orientation.transpose()<<std::endl;
+    //     }
+    // }
     //std::cout << "\n";
     before_out.close();
     std::ofstream after_out("../../outputs/3D_edges_after_smoothing.txt");
@@ -501,16 +524,16 @@ void EdgeMapping::align3DEdgesUsingEdgeNodes(EdgeNodeList& edge_nodes, int itera
     ///////////////////// find neighbor connection //////////////////////////////////
     //std::ofstream neighbor_file_after("../../outputs/target_indices_neighbors_after.txt");
 
-    for (auto i : target_indices) {
-        if (i >= static_cast<int>(edge_nodes.size())) continue; 
-        const auto& node = edge_nodes[i];
-        std::cout << "neighbors of " << node->location.transpose() << " after alignment are: " << std::endl;
-        for (const auto& neighbor_pair : node->neighbors) {
-            int neighbor_idx = neighbor_pair.first;
-            const EdgeNode* neighbor = neighbor_pair.second;
-            std::cout << neighbor->location.transpose() << " (Index: " << neighbor_idx << ")" << std::endl;
-        }
-    }
+    // for (auto i : target_indices) {
+    //     if (i >= static_cast<int>(edge_nodes.size())) continue; 
+    //     const auto& node = edge_nodes[i];
+    //     std::cout << "neighbors of " << node->location.transpose() << " after alignment are: " << std::endl;
+    //     for (const auto& neighbor_pair : node->neighbors) {
+    //         int neighbor_idx = neighbor_pair.first;
+    //         const EdgeNode* neighbor = neighbor_pair.second;
+    //         std::cout << neighbor->location.transpose() << " (Index: " << neighbor_idx << ")" << std::endl;
+    //     }
+    // }
     //neighbor_file_after.close();
     ///////////////////// find neighbor connection //////////////////////////////////
 
@@ -544,173 +567,254 @@ struct NeighborWithOrientation {
     }
 };
 
+EdgeMapping::ConnectivityGraph EdgeMapping::createConnectivityGraph(EdgeNodeList& edge_nodes) {
 
+    ConnectivityGraph connectivity_graph;
 
-// EdgeMapping::EdgeNodeList EdgeMapping::createEdgeNodesFromEdges(const std::vector<Eigen::Vector3d>& locations,
-//                                                                 const std::unordered_map<std::pair<Eigen::Vector3d, Eigen::Vector3d>, int, HashEigenVector3dPair, FuzzyVector3dPairEqual>& pruned_graph) 
-//                                                             {
-//     EdgeNodeList node_list;
-//     std::vector<EdgeNode*> raw_ptrs;
-//     FuzzyVector3dPairEqual fuzzy_equal;
-
-//     // Step 1: Create EdgeNodes from input
-//     for (const auto& location : locations) {
-//         for (const auto& [stored_loc, data] : edge_3D_to_supporting_edges) {
-//             if (location.isApprox(stored_loc, 1e-5)) { 
-//                 //std::cout << "found tangent for " << location.transpose() << std::endl;
-//                 std::unique_ptr<EdgeNode> node(new EdgeNode());
-//                 node->location = location;
-//                 node->orientation = data.front().tangents_3D_world.normalized();
-//                 raw_ptrs.push_back(node.get());
-//                 node_list.push_back(std::move(node));
-//                 break;
-//             }
-//         }
-//     }
-
-//     // Step 2: Check and establish neighbor relationships from pruned_graph
-//     for (const auto& [pair, weight] : pruned_graph) {
-//         Eigen::Vector3d a = pair.first;
-//         Eigen::Vector3d b = pair.second;
-
-//         EdgeNode* node_a = nullptr;
-//         EdgeNode* node_b = nullptr;
-
-//         for (auto* node : raw_ptrs) {
-//             if (!node_a && node->location.isApprox(a, 1e-6)) node_a = node;
-//             if (!node_b && node->location.isApprox(b, 1e-6)) node_b = node;
-//             if (node_a && node_b) break;
-//         }
-
-//         if (node_a && node_b) {
-//             node_a->neighbors.push_back(node_b);
-//             node_b->neighbors.push_back(node_a);
-//         }
-//     }
-
-//     // Step 3: Print final node list
-//     std::cout << "\n[INFO] Node Info for (0.86166 0.213932 0.354134):\n";
-//     for (size_t i = 0; i < raw_ptrs.size(); ++i) {
-//         const auto* node = raw_ptrs[i];
-//         Eigen::Vector3d target_node = Eigen::Vector3d(0.651729, 0.0931493,  0.354806);
-//         // if(node->location.isApprox(target_node, 1e-5)){
-//         //     std::cout << "  Location:    " << node->location.transpose() << std::endl;
-//         //     std::cout << "  Orientation: " << node->orientation.transpose() << std::endl;
-//         //     std::cout<<"neighbors: "<<std::endl;
-//         //     for (const auto* neighbor : node->neighbors) {
-//         //         std::cout << "    - " << neighbor->location.transpose() << "   "<<neighbor->orientation.transpose()<<std::endl;
-//         //     }
-//         // }
-//         // std::cout << "Node " << i + 1 << ":\n";
-//         // std::cout << "  Location:    " << node->location.transpose() << "\n";
-//         // std::cout << "  Orientation: " << node->orientation.transpose() << "\n";
-//         // std::cout << "  Neighbors:\n";
-//         // for (const auto* neighbor : node->neighbors) {
-//         //     std::cout << "    - " << neighbor->location.transpose() << "\n";
-//         // }
-//         // std::cout << std::endl;
-//     }
-//     return node_list;
-// }
-
-
-// EdgeMapping::EdgeNodeList EdgeMapping::createEdgeNodesFromFiles(const std::string& points_file, 
-//                                                                 const std::string& tangents_file, 
-//                                                                 const std::string& connections_file) {
-//     // Initialize the EdgeNodeList and a map to store nodes by index for easy referencing
-//     EdgeNodeList node_list;
-//     std::vector<EdgeNode*> node_ptrs;
+    if (!util) {util = std::shared_ptr<MultiviewGeometryUtil::multiview_geometry_util>(new MultiviewGeometryUtil::multiview_geometry_util());}
     
-//     // Read line points file
-//     std::ifstream points_infile(points_file);
-//     if (!points_infile.is_open()) {
-//         std::cerr << "Failed to open file: " << points_file << std::endl;
-//         return node_list;
-//     }
+    std::cout<<"Creating connectivity graph for " + std::to_string(edge_nodes.size()) + " edge nodes..."<<std::endl;
     
-//     // Read line tangents file
-//     std::ifstream tangents_infile(tangents_file);
-//     if (!tangents_infile.is_open()) {
-//         std::cerr << "Failed to open file: " << tangents_file << std::endl;
-//         return node_list;
-//     }
-    
-//     // Create nodes with their locations and orientations
-//     double x, y, z;
-//     size_t index = 0;
-    
-//     while (points_infile >> x >> y >> z) {
-//         Eigen::Vector3d location(x, y, z);
+    // for each node in the graph
+    for (size_t i = 0; i < edge_nodes.size(); ++i) {
+        EdgeNode* node = edge_nodes[i].get();
+
+        ConnectivityGraphNode graph_node;
+        graph_node.location = node->location;
+        graph_node.orientation = node->orientation;
+        graph_node.left_neighbor = std::make_pair(-1, Eigen::Vector3d::Zero());  // Default: no left neighbor
+        graph_node.right_neighbor = std::make_pair(-1, Eigen::Vector3d::Zero()); // Default: no right neighbor
         
-//         // Read tangent
-//         double tx, ty, tz;
-//         if (!(tangents_infile >> tx >> ty >> tz)) {
-//             std::cerr << "Error: Mismatch between points and tangents files at index " << index << std::endl;
-//             return node_list;
-//         }
-//         Eigen::Vector3d tangent(tx, ty, tz);
+        if (!node->neighbors.empty()) {
+            std::vector<std::pair<int, Eigen::Vector3d>> updated_neighbors;
+            std::vector<double> proj_neighbor;
+            
+            // Process each neighbor
+            for (const auto& neighbor_pair : node->neighbors) {
+                const int neighbor_index = neighbor_pair.first;
+                const EdgeNode* neighbor = neighbor_pair.second;
+                
+                double factor = (util->checkOrientationConsistency(node->orientation, neighbor->orientation)) ? 1.0 : -1.0;
+                if (factor < 0) { edge_nodes[neighbor_index]->orientation = -neighbor->orientation;}
+                
+                Eigen::Vector3d adjusted_orientation = neighbor->orientation;
+                updated_neighbors.push_back(std::make_pair(neighbor_index, adjusted_orientation));
+                
+                double line_latent_variable = util->getLineVariable(node->location, node->orientation, neighbor->location);
+                proj_neighbor.push_back(line_latent_variable);
+            }
+            
+            // Find left and right neighbors
+            int left_idx = -1;
+            double min_positive = std::numeric_limits<double>::max();
+            
+            int right_idx = -1;
+            double max_negative = -std::numeric_limits<double>::max();
+            
+            for (size_t j = 0; j < proj_neighbor.size(); ++j) {
+                if (proj_neighbor[j] >= 0 && proj_neighbor[j] < min_positive) {
+                    min_positive = proj_neighbor[j];
+                    left_idx = j;
+                }
+                if (proj_neighbor[j] < 0 && proj_neighbor[j] > max_negative) {
+                    max_negative = proj_neighbor[j];
+                    right_idx = j;
+                }
+            }
+            
+            // Update the connectivity graph node with left/right information
+            if (left_idx >= 0) {
+                int left_neighbor_index = updated_neighbors[left_idx].first;
+                Eigen::Vector3d left_neighbor_orientation = updated_neighbors[left_idx].second;
+                graph_node.left_neighbor = std::make_pair(left_neighbor_index, left_neighbor_orientation);
+                
+                // Update the orientation of the left neighbor in the edge_nodes
+                if (left_neighbor_index >= 0 && left_neighbor_index < edge_nodes.size()) {
+                    edge_nodes[left_neighbor_index]->orientation = left_neighbor_orientation;
+                }
+            }
+            
+            if (right_idx >= 0) {
+                int right_neighbor_index = updated_neighbors[right_idx].first;
+                Eigen::Vector3d right_neighbor_orientation = updated_neighbors[right_idx].second;
+                graph_node.right_neighbor = std::make_pair(right_neighbor_index, right_neighbor_orientation);
+                
+                // Update the orientation of the right neighbor in the edge_nodes
+                if (right_neighbor_index >= 0 && right_neighbor_index < edge_nodes.size()) {
+                    edge_nodes[right_neighbor_index]->orientation = right_neighbor_orientation;
+                }
+            }
+            
+            // Update all neighbor orientations to maintain consistency
+            for (const auto& updated_pair : updated_neighbors) {
+                int nbr_idx = updated_pair.first;
+                if (nbr_idx >= 0 && nbr_idx < edge_nodes.size()) {
+                    edge_nodes[nbr_idx]->orientation = updated_pair.second;
+                }
+            }
+        }
         
-//         std::unique_ptr<EdgeNode> node(new EdgeNode());
-//         node->location = location;
-//         node->orientation = tangent.normalized();
-        
-//         node_ptrs.push_back(node.get());
-        
-//         node_list.push_back(std::move(node));
-//         index++;
-//     }
+        // Add the node to the connectivity graph
+        connectivity_graph[i] = graph_node;
+    }
     
-//     points_infile.close();
-//     tangents_infile.close();
+    //writeConnectivityGraphToFile(connectivity_graph, "connectivity_graph");
     
-//     // Read connections file and establish neighbor relationships
-//     std::ifstream connections_infile(connections_file);
-//     if (!connections_infile.is_open()) {
-//         std::cerr << "Failed to open file: " << connections_file << std::endl;
-//         return node_list;
-//     }
-    
-//     std::string line;
-//     index = 0;
-    
-//     while (std::getline(connections_infile, line)) {
-//         if (index >= node_ptrs.size()) {
-//             std::cerr << "Error: More connection lines than nodes at index " << index << std::endl;
-//             break;
-//         }
-        
-//         EdgeNode* current_node = node_ptrs[index];
-        
-//         // Parse the line to get neighbor indices
-//         std::istringstream iss(line);
-//         int neighbor_index;
-        
-//         while (iss >> neighbor_index) {
-//             // Skip the current node's own index
-//             if (neighbor_index != index && neighbor_index >= 0 && neighbor_index < node_ptrs.size()) {
-//                 // Add neighbor to current node
-//                 current_node->neighbors.push_back(node_ptrs[neighbor_index]);
-//             }
-//         }
-//         index++;
-//     }
-    
-//     connections_infile.close();
-    
-//     // Print node list information
-//     std::cout << "\n[NODE LIST SUMMARY]" << std::endl;
-//     std::cout << "Total nodes: " << node_list.size() << std::endl;
-//     std::cout << "[INFO] Created " << node_list.size() << " edge nodes with connections from files." << std::endl;
-//     return node_list;
-// }
-// ////////////////// test //////////////////
+    return connectivity_graph;
+}
 
+
+
+void EdgeMapping::writeConnectivityGraphToFile(const ConnectivityGraph& graph, const std::string& file_name) {
+    std::string file_path = "../../outputs/" + file_name + ".txt";
+    std::ofstream outfile(file_path);
+    
+    if (!outfile.is_open()) {
+        return;
+    }
+    
+    outfile << "# Connectivity Graph\n";
+    outfile << "# Format: NodeIndex Location(x,y,z) Orientation(x,y,z) LeftNeighborIndex LeftOrientation(x,y,z) RightNeighborIndex RightOrientation(x,y,z)\n";
+    
+    for (const auto& pair : graph) {
+        int node_index = pair.first;
+        const ConnectivityGraphNode& node = pair.second;
+        
+        outfile << node_index << " "
+                << node.location.x() << " " << node.location.y() << " " << node.location.z() << " "
+                << node.orientation.x() << " " << node.orientation.y() << " " << node.orientation.z() << " "
+                << node.left_neighbor.first << " ";
+        
+        if (node.left_neighbor.first >= 0) {
+            outfile << node.left_neighbor.second.x() << " " << node.left_neighbor.second.y() << " " << node.left_neighbor.second.z() << " ";
+        } else {
+            outfile << "0 0 0 ";
+        }
+        
+        outfile << node.right_neighbor.first << " ";
+        
+        if (node.right_neighbor.first >= 0) {
+            outfile << node.right_neighbor.second.x() << " " << node.right_neighbor.second.y() << " " << node.right_neighbor.second.z();
+        } else {
+            outfile << "0 0 0";
+        }
+        outfile << "\n";
+    }
+    outfile.close();
+}
+
+// Define a Curve as a sequence of edge node indices
+struct Curve {
+    std::vector<int> edge_indices;
+};
+
+void EdgeMapping::writeCurvesToFile(const std::vector<Curve>& curves, 
+                                   const ConnectivityGraph& connectivity_graph, 
+                                   const std::string& file_name, bool b_write_curve_info) {
+    std::string file_path = "../../outputs/" + file_name + ".txt";
+    std::ofstream outfile(file_path);
+    
+    if (!outfile.is_open()) {
+        std::cerr << "Could not open " << file_path << " for writing." << std::endl;
+        return;
+    }
+    
+    if (b_write_curve_info) {
+        outfile << "# Curves from Connectivity Graph\n";
+        outfile << "# Format: CurveID NodeIndex Location(x,y,z) Orientation(x,y,z)\n";
+    }
+    
+    for (size_t curve_id = 0; curve_id < curves.size(); ++curve_id) {
+        const auto& curve = curves[curve_id];
+        
+        for (const auto& node_index : curve.edge_indices) {
+            const auto& node = connectivity_graph.at(node_index);
+            
+            if (b_write_curve_info) {
+                outfile << curve_id << " " << node_index << " "
+                        << node.location.x() << " " << node.location.y() << " " << node.location.z() << " "
+                        << node.orientation.x() << " " << node.orientation.y() << " " << node.orientation.z() << "\n";
+            }
+            else {
+                outfile << node.location.x() << " " << node.location.y() << " " << node.location.z() << " "
+                        << node.orientation.x() << " " << node.orientation.y() << " " << node.orientation.z() << "\n";
+            }
+        }
+        
+        // Add a blank line between curves for better visualization
+        if (b_write_curve_info) outfile << "\n";
+    }
+    
+    outfile.close();
+    std::cout << "Wrote " << curves.size() << " curves to " << file_path << std::endl;
+}
+
+std::vector<EdgeMapping::Curve> EdgeMapping::buildCurvesFromConnectivityGraph(const ConnectivityGraph& connectivity_graph) {
+    std::vector<Curve> curves;
+    std::unordered_set<int> assigned_edges;
+    
+    // Loop until all edges are assigned to a curve
+    for (const auto& [node_index, node] : connectivity_graph) {
+        // Skip if this edge is already assigned to a curve
+        if (assigned_edges.find(node_index) != assigned_edges.end()) {
+            continue;
+        }
+        
+        // Create a new curve starting with this edge
+        Curve curve;
+        curve.edge_indices.push_back(node_index);
+        assigned_edges.insert(node_index);
+        
+        // Forward step: follow right neighbors until we can't go further
+        int current_index = node_index;
+        while (true) {
+            const auto& current_node = connectivity_graph.at(current_index);
+            int right_neighbor_index = current_node.right_neighbor.first;
+            
+            // Stop if no right neighbor or already assigned
+            if (right_neighbor_index < 0 || 
+                connectivity_graph.find(right_neighbor_index) == connectivity_graph.end() ||
+                assigned_edges.find(right_neighbor_index) != assigned_edges.end()) {
+                break;
+            }
+            
+            // Add right neighbor to curve and mark as assigned
+            curve.edge_indices.push_back(right_neighbor_index);
+            assigned_edges.insert(right_neighbor_index);
+            current_index = right_neighbor_index;
+        }
+        
+        // Backward step: follow left neighbors until we can't go further
+        current_index = node_index;
+        while (true) {
+            const auto& current_node = connectivity_graph.at(current_index);
+            int left_neighbor_index = current_node.left_neighbor.first;
+            
+            // Stop if no left neighbor or already assigned
+            if (left_neighbor_index < 0 || 
+                connectivity_graph.find(left_neighbor_index) == connectivity_graph.end() ||
+                assigned_edges.find(left_neighbor_index) != assigned_edges.end()) {
+                break;
+            }
+            
+            // Add left neighbor to beginning of curve and mark as assigned
+            curve.edge_indices.insert(curve.edge_indices.begin(), left_neighbor_index);
+            assigned_edges.insert(left_neighbor_index);
+            current_index = left_neighbor_index;
+        }
+        
+        //if (curve.edge_indices.size() >= 5){
+        curves.push_back(curve);
+        //}
+    }
+    
+    return curves;
+}
 
 std::vector<std::vector<EdgeMapping::SupportingEdgeData>> EdgeMapping::findMergable2DEdgeGroups(const std::vector<Eigen::Matrix3d> all_R,
                                                                                                 const std::vector<Eigen::Vector3d> all_T,
                                                                                                 const Eigen::Matrix3d K,
                                                                                                 const int Num_Of_Total_Imgs) { 
-
 
     int num_iteration = 1000;
     double step_size_force = 0.01;
@@ -726,105 +830,109 @@ std::vector<std::vector<EdgeMapping::SupportingEdgeData>> EdgeMapping::findMerga
     // crate 3d -> its neighbor data structure
     auto neighbor_map = buildEdgeNodeGraph(pruned_graph_by_projection);
     align3DEdgesUsingEdgeNodes(neighbor_map, num_iteration, step_size_force, step_size_torque); //call it align
+    auto connectivity_graph = createConnectivityGraph(neighbor_map);
+    auto curves = buildCurvesFromConnectivityGraph(connectivity_graph);
+    writeCurvesToFile(curves, connectivity_graph, "curves_from_connectivity_graph", true);
+    writeCurvesToFile(curves, connectivity_graph, "curves_points", false);
 
-    /////////// TEST: manually create and iteratively smooth 2 test EdgeNodes  /////////// 
+    // /////////// TEST: manually create and iteratively smooth 2 test EdgeNodes  /////////// 
 
-    /////////// Create EdgeNodes from input files ///////////
-    std::string points_file = "../../files/line_noisy_points.txt";
-    std::string tangents_file = "../../files/line_noisy_tangents.txt";
-    std::string connections_file = "../../files/line_connections.txt";
+    // /////////// Create EdgeNodes from input files ///////////
+    // std::string points_file = "../../files/line_noisy_points.txt";
+    // std::string tangents_file = "../../files/line_noisy_tangents.txt";
+    // std::string connections_file = "../../files/line_connections.txt";
     
-    //EdgeNodeList test_node = createEdgeNodesFromFiles(points_file, tangents_file, connections_file);
+    // //EdgeNodeList test_node = createEdgeNodesFromFiles(points_file, tangents_file, connections_file);
 
-    //align3DEdgesUsingEdgeNodes(test_node, num_iteration); //call it align
+    // //align3DEdgesUsingEdgeNodes(test_node, num_iteration); //call it align
 
     std::vector<std::vector<SupportingEdgeData>> merged_groups;
 
-    // Projection view's extrinsics
-    Eigen::Matrix3d R_view = all_R[7];
-    Eigen::Vector3d T_view = all_T[7];
-    util = std::shared_ptr<MultiviewGeometryUtil::multiview_geometry_util>(new MultiviewGeometryUtil::multiview_geometry_util());
+    // // Projection view's extrinsics
+    // Eigen::Matrix3d R_view = all_R[7];
+    // Eigen::Vector3d T_view = all_T[7];
+    // util = std::shared_ptr<MultiviewGeometryUtil::multiview_geometry_util>(new MultiviewGeometryUtil::multiview_geometry_util());
 
-    std::ofstream proj_outfile("../../outputs/3D_edge_groups_projected.txt");
-    if (!proj_outfile.is_open()) {
-        std::cerr << "Could not open 3D edge group projection output file!" << std::endl;
-        return merged_groups;
-    }
+    // std::ofstream proj_outfile("../../outputs/3D_edge_groups_projected.txt");
+    // if (!proj_outfile.is_open()) {
+    //     std::cerr << "Could not open 3D edge group projection output file!" << std::endl;
+    //     return merged_groups;
+    // }
 
-    std::ofstream edge_3d_outfile("../../outputs/3D_edge_groups.txt");
-    if (!edge_3d_outfile.is_open()) {
-        std::cerr << "Could not open 3D edge projection output file!" << std::endl;
-        return merged_groups;
-    }
+    // std::ofstream edge_3d_outfile("../../outputs/3D_edge_groups.txt");
+    // if (!edge_3d_outfile.is_open()) {
+    //     std::cerr << "Could not open 3D edge projection output file!" << std::endl;
+    //     return merged_groups;
+    // }
 
-    Eigen::Vector3d target1(0.0684783,  0.746448,  0.500493);
-    // Eigen::Vector3d target2(0.710306, 0.877993, 0.353316);
-    // Eigen::Vector3d target3(0.704316, 0.884627,  0.35257);
+    // Eigen::Vector3d target1(0.0684783,  0.746448,  0.500493);
+    // // Eigen::Vector3d target2(0.710306, 0.877993, 0.353316);
+    // // Eigen::Vector3d target3(0.704316, 0.884627,  0.35257);
 
-    // Set to collect neighbors of target1 and target2
-    std::set<NeighborWithOrientation> neighbors_of_target1;
-    // std::set<NeighborWithOrientation> neighbors_of_target2;
-    // std::set<NeighborWithOrientation> neighbors_of_target3;
+    // // Set to collect neighbors of target1 and target2
+    // std::set<NeighborWithOrientation> neighbors_of_target1;
+    // // std::set<NeighborWithOrientation> neighbors_of_target2;
+    // // std::set<NeighborWithOrientation> neighbors_of_target3;
 
-    int group_id = 0;
-    //for (const auto& [pair, weight] : pruned_graph_by_projection) {
-    for (const auto& [pair, weight] : pruned_graph) {
-        const Eigen::Vector3d& p1 = pair.first;
-        const Eigen::Vector3d& p2 = pair.second;
+    // int group_id = 0;
+    // //for (const auto& [pair, weight] : pruned_graph_by_projection) {
+    // for (const auto& [pair, weight] : pruned_graph) {
+    //     const Eigen::Vector3d& p1 = pair.first;
+    //     const Eigen::Vector3d& p2 = pair.second;
 
-        // Retrieve tangents
-        Eigen::Vector3d tangent1 = Eigen::Vector3d::Zero();
-        Eigen::Vector3d tangent2 = Eigen::Vector3d::Zero();
+    //     // Retrieve tangents
+    //     Eigen::Vector3d tangent1 = Eigen::Vector3d::Zero();
+    //     Eigen::Vector3d tangent2 = Eigen::Vector3d::Zero();
 
-        auto it1 = edge_3D_to_supporting_edges.find(p1);
-        auto it2 = edge_3D_to_supporting_edges.find(p2);
+    //     auto it1 = edge_3D_to_supporting_edges.find(p1);
+    //     auto it2 = edge_3D_to_supporting_edges.find(p2);
 
-        bool valid_tangents = false;
-        if (it1 != edge_3D_to_supporting_edges.end() && !it1->second.empty() &&
-            it2 != edge_3D_to_supporting_edges.end() && !it2->second.empty()) {
-            tangent1 = it1->second.front().tangents_3D_world.normalized();
-            tangent2 = it2->second.front().tangents_3D_world.normalized();
-            valid_tangents = true;
-        }
+    //     bool valid_tangents = false;
+    //     if (it1 != edge_3D_to_supporting_edges.end() && !it1->second.empty() &&
+    //         it2 != edge_3D_to_supporting_edges.end() && !it2->second.empty()) {
+    //         tangent1 = it1->second.front().tangents_3D_world.normalized();
+    //         tangent2 = it2->second.front().tangents_3D_world.normalized();
+    //         valid_tangents = true;
+    //     }
 
-        ///////////// find neighbors of the target point /////////////
-        if (valid_tangents){
-            const Eigen::Vector3d& a = pair.first;
-            const Eigen::Vector3d& b = pair.second;
+    //     ///////////// find neighbors of the target point /////////////
+    //     if (valid_tangents){
+    //         const Eigen::Vector3d& a = pair.first;
+    //         const Eigen::Vector3d& b = pair.second;
 
-            // if (b.isApprox(Eigen::Vector3d(0.499562, -0.00378834, 0.541387), 1e-6)) {
-            //     std::cout << "{Eigen::Vector3d(0.499562, -0.00378834, 0.541387), Eigen::Vector3d(" << tangent2.transpose() << ")}," << std::endl;
-            // }
+    //         // if (b.isApprox(Eigen::Vector3d(0.499562, -0.00378834, 0.541387), 1e-6)) {
+    //         //     std::cout << "{Eigen::Vector3d(0.499562, -0.00378834, 0.541387), Eigen::Vector3d(" << tangent2.transpose() << ")}," << std::endl;
+    //         // }
 
-            if (a.isApprox(target1, 1e-6)) 
-                neighbors_of_target1.insert({b, tangent2});
-            else if (b.isApprox(target1, 1e-6)) 
-                neighbors_of_target1.insert({a, tangent1});
+    //         if (a.isApprox(target1, 1e-6)) 
+    //             neighbors_of_target1.insert({b, tangent2});
+    //         else if (b.isApprox(target1, 1e-6)) 
+    //             neighbors_of_target1.insert({a, tangent1});
 
-            // if (a.isApprox(target2, 1e-6)) 
-            //     neighbors_of_target2.insert({b, tangent2});
-            // else if (b.isApprox(target2, 1e-6)) 
-            //     neighbors_of_target2.insert({a, tangent1});
+    //         // if (a.isApprox(target2, 1e-6)) 
+    //         //     neighbors_of_target2.insert({b, tangent2});
+    //         // else if (b.isApprox(target2, 1e-6)) 
+    //         //     neighbors_of_target2.insert({a, tangent1});
 
-            // if (a.isApprox(target3, 1e-6)) 
-            //     neighbors_of_target3.insert({b, tangent2});
-            // else if (b.isApprox(target3, 1e-6)) 
-            //     neighbors_of_target3.insert({a, tangent1});
-        }
-        ///////////// find neighbors of the target point /////////////
+    //         // if (a.isApprox(target3, 1e-6)) 
+    //         //     neighbors_of_target3.insert({b, tangent2});
+    //         // else if (b.isApprox(target3, 1e-6)) 
+    //         //     neighbors_of_target3.insert({a, tangent1});
+    //     }
+    //     ///////////// find neighbors of the target point /////////////
 
-    }
+    // }
 
-    // smoothed_proj_out.close();
+    // // smoothed_proj_out.close();
 
-    std::cout<<"neighbors of target 1 are: "<<std::endl;
-    for (auto& n1 : neighbors_of_target1) {
-        //for (const auto& n2 : neighbors_of_target2) {
-        //    if (n1.isApprox(n2, 1e-6)) {
-        std::cout << n1.location.transpose() << "\n";
-        //    }
-       // }
-    }
+    // std::cout<<"neighbors of target 1 are: "<<std::endl;
+    // for (auto& n1 : neighbors_of_target1) {
+    //     //for (const auto& n2 : neighbors_of_target2) {
+    //     //    if (n1.isApprox(n2, 1e-6)) {
+    //     std::cout << n1.location.transpose() << "\n";
+    //     //    }
+    //    // }
+    // }
     
     return merged_groups;
 }

--- a/Edge_Reconst/edge_mapping.hpp
+++ b/Edge_Reconst/edge_mapping.hpp
@@ -105,9 +105,20 @@ public:
         std::vector<std::pair<int, EdgeNode*>> neighbors;
     };
 
+    struct ConnectivityGraphNode {
+        Eigen::Vector3d location;  
+        Eigen::Vector3d orientation;      
+        std::pair<int, Eigen::Vector3d> left_neighbor;  
+        std::pair<int, Eigen::Vector3d> right_neighbor; 
+    };
+
+    struct Curve {
+        std::vector<int> edge_indices;
+    };
+
 
     using PointerNeighborMap = std::unordered_map<const Eigen::Vector3d*, std::vector<std::pair<const Eigen::Vector3d*, std::pair<Eigen::Vector3d, Eigen::Vector3d>>>>;
-
+    using ConnectivityGraph = std::unordered_map<int, ConnectivityGraphNode>;
 
     
     // Custom hash function
@@ -171,16 +182,20 @@ public:
 
     void align3DEdgesUsingEdgeNodes(EdgeNodeList& edge_nodes, int iterations, double step_size_force, double step_size_torque);
 
-    std::unordered_map<std::pair<Eigen::Vector3d, Eigen::Vector3d>, int, 
-                   HashEigenVector3dPair, FuzzyVector3dPairEqual>
-    pruneEdgeGraphbyProjections(
-    std::unordered_map<std::pair<Eigen::Vector3d, Eigen::Vector3d>, int, 
-                       HashEigenVector3dPair, FuzzyVector3dPairEqual>& graph,
-    const std::vector<Eigen::Matrix3d> All_R,
-    const std::vector<Eigen::Vector3d> All_T,
-    const Eigen::Matrix3d K,
-    const int Num_Of_Total_Imgs
-    );
+    ConnectivityGraph createConnectivityGraph(EdgeNodeList& edge_nodes);
+
+    void writeConnectivityGraphToFile(const ConnectivityGraph& graph, const std::string& file_name);
+    std::vector<Curve> buildCurvesFromConnectivityGraph(const ConnectivityGraph& connectivity_graph);
+    void writeCurvesToFile(const std::vector<Curve>& curves, const ConnectivityGraph& connectivity_graph, const std::string& file_name, bool b_write_curve_info);
+    
+    std::unordered_map<std::pair<Eigen::Vector3d, Eigen::Vector3d>, int, HashEigenVector3dPair, FuzzyVector3dPairEqual> pruneEdgeGraphbyProjections(
+                                                                                                                                                    std::unordered_map<std::pair<Eigen::Vector3d, Eigen::Vector3d>, int, 
+                                                                                                                                                    HashEigenVector3dPair, FuzzyVector3dPairEqual>& graph,
+                                                                                                                                                    const std::vector<Eigen::Matrix3d> All_R,
+                                                                                                                                                    const std::vector<Eigen::Vector3d> All_T,
+                                                                                                                                                    const Eigen::Matrix3d K,
+                                                                                                                                                    const int Num_Of_Total_Imgs
+                                                                                                                                                    );
 
 private:
     std::shared_ptr<MultiviewGeometryUtil::multiview_geometry_util> util = nullptr;

--- a/Edge_Reconst/mvt.cpp
+++ b/Edge_Reconst/mvt.cpp
@@ -304,19 +304,19 @@ void writeTangentFile(const std::string& outputTangentFilePath, const std::vecto
 /////////////////////////////////// 3D RECONSTRUCTION ///////////////////////////////////////////////////////
 
 
-Eigen::MatrixXd mvt(int hyp1, int hyp2) {
+Eigen::MatrixXd mvt(int hyp1, int hyp2, std::string Scene_Name) {
 
     std::string basePath = "../../outputs/";
     std::string filePath = basePath + "paired_edges_final_" + std::to_string(hyp1) + "_" + std::to_string(hyp2) + ".txt";
-    std::string outputFilePath = basePath + "triangulated_3D_edges_ABC-NEF_00000006_hypo1_" + 
+    std::string outputFilePath = basePath + "triangulated_3D_edges_ABC-NEF_" + Scene_Name + "_hypo1_" + 
                                 std::to_string(hyp1) + "_hypo2_" + std::to_string(hyp2) + 
-                                "_t1to1_delta03_theta15.000000_N4.txt";
-    std::string points3DFile = basePath + "3D_edges_ABC-NEF_00000006_hypo1_" + 
+                                "_t4to4_delta03_theta15.000000_N4.txt";
+    std::string points3DFile = basePath + "3D_edges_ABC-NEF_" + Scene_Name + "_hypo1_" + 
                             std::to_string(hyp1) + "_hypo2_" + std::to_string(hyp2) + 
-                            "_t1to1_delta03_theta15.000000_N4.txt";
-    std::string tangentFilePath = basePath + "3D_tangents_ABC-NEF_00000006_hypo1_" + 
+                            "_t4to4_delta03_theta15.000000_N4.txt";
+    std::string tangentFilePath = basePath + "3D_tangents_ABC-NEF_" + Scene_Name + "_hypo1_" + 
                             std::to_string(hyp1) + "_hypo2_" + std::to_string(hyp2) + 
-                            "_t1to1_delta03_theta15.000000_N4.txt";
+                            "_t4to4_delta03_theta15.000000_N4.txt";
     std::string outputTangentFilePath = "../../outputs/updated_tangents.txt"; 
     std::vector<Eigen::Vector3d> points3D;
 

--- a/Edge_Reconst/mvt.hpp
+++ b/Edge_Reconst/mvt.hpp
@@ -39,7 +39,7 @@ void loadRTMatrices(const std::string& R_file_path, const std::string& T_file_pa
 std::vector<std::vector<EdgeData>> parseFile(const std::string& filePath);
 std::vector<Eigen::Vector3d> readTangentFile(const std::string& tangentFilePath);
 void writeTangentFile(const std::string& outputTangentFilePath, const std::vector<Eigen::Vector3d>& tangents);
-Eigen::MatrixXd mvt(int hyp1, int hyp2);
+Eigen::MatrixXd mvt(int hyp1, int hyp2, std::string Scene_Name);
 void grouped_mvt(const std::vector<std::vector<EdgeMapping::SupportingEdgeData>>& all_groups, const std::string& outputFilePath, const std::string& tangentOutputFilePath);
 
 } // namespace NViewsTrian

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ where ``XXX`` is the installed prefix path of your YAML-CPP.
 Some intermidiate data when running the code will be saved to files which are stored in a ``outputs/`` folder. All files will be cleared out when the code starts a new run. This can be deactivated by setting the macro ``DELETE_ALL_FILES_UNDER_OUTPUTS`` defined in the ``Edge_Reconst/definitions.h`` file as _false_.
 
 ## Evaluations
-A evaluation script is customized and created under ``evaluation`` folder. For ABC-NEF dataset, you can download the ground-truth sampled curve points from [Google Drive](). It is encouraged to launch a conda environment before running the evaluation script. Follow the commands below to install:
+A evaluation script is customized and created under ``evaluation`` folder. For ABC-NEF dataset, you can download the ground-truth sampled curve points from [Google Drive](https://drive.google.com/drive/folders/1FH8_jykq44YA4FGJ6Par4gBMZg7Ayp1q?usp=sharing). It is encouraged to launch a conda environment before running the evaluation script. Follow the commands below to install:
 ```bash
 conda create -n edge_sketch python=3.8
 conda activate edge_sketch

--- a/README.md
+++ b/README.md
@@ -27,6 +27,19 @@ where ``XXX`` is the installed prefix path of your YAML-CPP.
 ## Outputs
 Some intermidiate data when running the code will be saved to files which are stored in a ``outputs/`` folder. All files will be cleared out when the code starts a new run. This can be deactivated by setting the macro ``DELETE_ALL_FILES_UNDER_OUTPUTS`` defined in the ``Edge_Reconst/definitions.h`` file as _false_.
 
+## Evaluations
+A evaluation script is customized and created under ``evaluation`` folder. For ABC-NEF dataset, you can download the ground-truth sampled curve points from [Google Drive](). It is encouraged to launch a conda environment before running the evaluation script. Follow the commands below to install:
+```bash
+conda create -n edge_sketch python=3.8
+conda activate edge_sketch
+pip install -r requirements.txt
+```
+Then, let's say ``outputs/curves_points`` is the 3D edge locations obtained from the 3D edge sketch, run the evaluation script to get the precision, recall, accuracy, completeness, and F-score:
+```bash
+python eval_main.py
+```
+Refer to ``eval_main.py`` for more information on where the ground-truth curve points directory is specified.
+
 ## Test
 There is a test file under ``test/`` which is primarily used to test part of the functionalities of the 3D edge sketch and grouping. It is compiled in conjunction with the main code, and the executable file resides uner ``/buid/bin``.
 

--- a/cmd/main.cpp
+++ b/cmd/main.cpp
@@ -99,7 +99,8 @@ int main(int argc, char **argv) {
     MWV_Edge_Rec.Set_Hypothesis_Views_Camera();
 
     //> Multiple edge thresholding
-    for (int edge_thresh = MWV_Edge_Rec.Edge_Detection_Init_Thresh; edge_thresh >= 1; edge_thresh/=2) {
+    for (int edge_thresh = MWV_Edge_Rec.Edge_Detection_Init_Thresh; edge_thresh >= MWV_Edge_Rec.Edge_Detection_Final_Thresh; edge_thresh/=2) {
+
       std::cout << "- Edge Threshold = " << edge_thresh << std::endl;
       MWV_Edge_Rec.thresh_EDG = edge_thresh;
 
@@ -143,10 +144,10 @@ int main(int argc, char **argv) {
   std::cout << "====================================================================" << std::endl;
 
   std::vector<std::vector<EdgeMapping::SupportingEdgeData>> all_groups = edgeMapping->findMergable2DEdgeGroups(MWV_Edge_Rec.All_R, MWV_Edge_Rec.All_T, MWV_Edge_Rec.K, MWV_Edge_Rec.Num_Of_Total_Imgs);
-  std::string outputFilePath = "../../outputs/grouped_mvt.txt";
-  std::string outputFilePath_tangent = "../../outputs/grouped_mvt_tangent.txt";
-  NViewsTrian::grouped_mvt(all_groups, outputFilePath, outputFilePath_tangent);
-  std::cout << "[INFO] Triangulated 3D edges saved to " << outputFilePath << std::endl;
+  // std::string outputFilePath = "../../outputs/grouped_mvt.txt";
+  // std::string outputFilePath_tangent = "../../outputs/grouped_mvt_tangent.txt";
+  // NViewsTrian::grouped_mvt(all_groups, outputFilePath, outputFilePath_tangent);
+  // std::cout << "[INFO] Triangulated 3D edges saved to " << outputFilePath << std::endl;
 
   //////////////////// Merge edges ////////////////////
 

--- a/evaluation/eval_main.py
+++ b/evaluation/eval_main.py
@@ -1,0 +1,189 @@
+import os
+import numpy as np
+import argparse
+import open3d as o3d
+import logging
+import sys
+
+from eval_util import (
+    set_random_seeds,
+    compute_chamfer_distance,
+    f_score,
+    compute_precision_recall_IOU
+)
+
+def txt_to_numpy_array(file_path, delimiter=None, dtype=None):
+    try:
+        # Use np.loadtxt to read the data from the text file
+        array = np.loadtxt(file_path, delimiter=delimiter, dtype=dtype)
+        return array
+    except Exception as e:
+        print(f"Error reading file: {e}")
+        return None
+
+def update_totals_and_metrics(metrics, totals, results, edge_type):
+    correct_gt, num_gt, correct_pred, num_pred, acc, comp = results
+    metrics[f"comp_{edge_type}"].append(comp)
+    metrics[f"acc_{edge_type}"].append(acc)
+    for i, threshold in enumerate(["5", "10", "20"]):
+        totals[f"thre{threshold}_correct_gt_total"] += correct_gt[i]
+        totals[f"thre{threshold}_correct_pred_total"] += correct_pred[i]
+    totals["num_gt_total"] += num_gt
+    totals["num_pred_total"] += num_pred
+
+
+def finalize_metrics(metrics):
+    for key, value in metrics.items():
+        value = np.array(value)
+        value[np.isnan(value)] = 0
+        metrics[key] = round(np.mean(value), 4)
+    return metrics
+
+
+def print_metrics(metrics, totals, edge_type):
+    print(f"{edge_type.capitalize()}:")
+    print(f"  Completeness: {metrics[f'comp_{edge_type}']}")
+    print(f"  Accuracy: {metrics[f'acc_{edge_type}']}")
+
+
+def eval_3D_edges(obj_name, base_dir, output_name, GT_dir, metrics, totals):
+    #> get the 3D edge sketch curve points
+    print(f"Processing: {obj_name}")
+    out_cruve_points_path = os.path.join( base_dir, output_name, "curves_points.txt" )
+    print( out_cruve_points_path )
+    if not os.path.exists( out_cruve_points_path ):
+        print(f"Invalid 3D edge sketch result at {obj_name}")
+        return
+
+    edge_sketch_curve_points = txt_to_numpy_array( out_cruve_points_path )
+    if len(edge_sketch_curve_points) == 0:
+        print(f"Invalid 3D edge sketch at {obj_name}")
+        return
+
+    print(edge_sketch_curve_points)
+
+    #> get the ground-truth 3D curve points
+    gt_cruve_points_path = os.path.join( base_dir, GT_dir, f'{obj_name}.txt' )
+    print( gt_cruve_points_path )
+    if not os.path.exists( gt_cruve_points_path ):
+        print(f"Invalid GT curve points at {gt_cruve_points_path}")
+        return
+    
+    gt_points = txt_to_numpy_array( gt_cruve_points_path )
+    if len(gt_points) == 0:
+        print(f"Invalid GT curve points at {obj_name}")
+        return
+
+    chamfer_dist, acc, comp = compute_chamfer_distance(edge_sketch_curve_points, gt_points)
+    print(
+        f"  Chamfer Distance: {chamfer_dist:.4f}, Accuracy: {acc:.4f}, Completeness: {comp:.4f}"
+    )
+    metrics["chamfer"].append(chamfer_dist)
+    metrics["acc"].append(acc)
+    metrics["comp"].append(comp)
+
+    # #> Write GT edge points to a ply file
+    # gt_edge_pcd = o3d.geometry.PointCloud()
+    # gt_edge_pcd.points = o3d.utility.Vector3dVector(gt_points)
+
+    # gt_edge_ply_file_path = os.path.join(base_dir, obj_name, exp_name, "results", "gt_edge_points.ply")
+    # try:
+    #     o3d.io.write_point_cloud(gt_edge_ply_file_path, gt_edge_pcd, write_ascii=True)
+    #     logging.info(f"Saved {gt_edge_ply_file_path} for edge points visualization.")
+    # except IOError as e:
+    #     logging.error(f"Failed to save {gt_edge_ply_file_path}: {e}")
+
+    metrics = compute_precision_recall_IOU(
+        edge_sketch_curve_points,
+        gt_points,
+        metrics,
+        thresh_list=[0.005, 0.01, 0.02],
+        edge_type="all",
+    )
+
+
+def main(base_dir, GT_dir, exp_name):
+    eval_obj_name = "00004605"
+    set_random_seeds()
+    metrics = {
+        "chamfer": [],
+        "acc": [],
+        "comp": [],
+        "comp_curve": [],
+        "comp_line": [],
+        "acc_curve": [],
+        "acc_line": [],
+        "precision_0.01": [],
+        "recall_0.01": [],
+        "fscore_0.01": [],
+        "IOU_0.01": [],
+        "precision_0.02": [],
+        "recall_0.02": [],
+        "fscore_0.02": [],
+        "IOU_0.02": [],
+        "precision_0.005": [],
+        "recall_0.005": [],
+        "fscore_0.005": [],
+        "IOU_0.005": [],
+    }
+
+    totals = {
+        "curve": {
+            "thre5_correct_gt_total": 0,
+            "thre10_correct_gt_total": 0,
+            "thre20_correct_gt_total": 0,
+            "thre5_correct_pred_total": 0,
+            "thre10_correct_pred_total": 0,
+            "thre20_correct_pred_total": 0,
+            "num_gt_total": 0,
+            "num_pred_total": 0,
+        },
+        "line": {
+            "thre5_correct_gt_total": 0,
+            "thre10_correct_gt_total": 0,
+            "thre20_correct_gt_total": 0,
+            "thre5_correct_pred_total": 0,
+            "thre10_correct_pred_total": 0,
+            "thre20_correct_pred_total": 0,
+            "num_gt_total": 0,
+            "num_pred_total": 0,
+        },
+    }
+
+    eval_3D_edges(eval_obj_name, base_dir, exp_name, GT_dir, metrics, totals)
+
+    metrics = finalize_metrics(metrics)
+
+    print("Summary:")
+    print(f"  Accuracy: {metrics['acc']:.4f}")
+    print(f"  Completeness: {metrics['comp']:.4f}")
+    print(f"  Recall @ 5 mm: {metrics['recall_0.005']:.4f}")
+    print(f"  Recall @ 10 mm: {metrics['recall_0.01']:.4f}")
+    print(f"  Recall @ 20 mm: {metrics['recall_0.02']:.4f}")
+    print(f"  Precision @ 5 mm: {metrics['precision_0.005']:.4f}")
+    print(f"  Precision @ 10 mm: {metrics['precision_0.01']:.4f}")
+    print(f"  Precision @ 20 mm: {metrics['precision_0.02']:.4f}")
+    print(f"  F-Score @ 5 mm: {metrics['fscore_0.005']:.4f}")
+    print(f"  F-Score @ 10 mm: {metrics['fscore_0.01']:.4f}")
+    print(f"  F-Score @ 20 mm: {metrics['fscore_0.02']:.4f}")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Process CAD data and compute metrics."
+    )
+    parser.add_argument(
+        "--base_dir",
+        type=str,
+        default="/gpfs/data/bkimia/cchien3/Qiwu_Edge_Grouping/3D_Edge_Sketch_and_Grouping/",
+        help="Base directory for 3D Edge Sketch",
+    )
+    parser.add_argument(
+        "--GT_dir",
+        type=str,
+        default="evaluation/gt_curve_points/",
+        help="Directory for the GT 3D curve points",
+    )
+    parser.add_argument("--output_name", type=str, default="outputs", help="output folder name")
+
+    args = parser.parse_args()
+    main(args.base_dir, args.GT_dir, args.output_name)

--- a/evaluation/eval_main.py
+++ b/evaluation/eval_main.py
@@ -180,7 +180,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--GT_dir",
         type=str,
-        default="evaluation/gt_curve_points/",
+        default="/gpfs/data/bkimia/Datasets/ABC-NEF/gt_curve_points/",
         help="Directory for the GT 3D curve points",
     )
     parser.add_argument("--output_name", type=str, default="outputs", help="output folder name")

--- a/evaluation/eval_util.py
+++ b/evaluation/eval_util.py
@@ -1,0 +1,296 @@
+import os
+import numpy as np
+import json
+import point_cloud_utils as pcu
+import math
+import random
+from pathlib import Path
+
+
+def set_random_seeds(seed=42):
+    np.random.seed(seed)
+    random.seed(seed)
+    
+def chamfer_distance(x, y, return_index=False, p_norm=2, max_points_per_leaf=10):
+    """
+    Compute the chamfer distance between two point clouds x, and y
+
+    Args:
+        x : A m-sized minibatch of point sets in R^d. i.e. shape [m, n_a, d]
+        y : A m-sized minibatch of point sets in R^d. i.e. shape [m, n_b, d]
+        return_index: If set to True, will return a pair (corrs_x_to_y, corrs_y_to_x) where
+                    corrs_x_to_y[i] stores the index into y of the closest point to x[i]
+                    (i.e. y[corrs_x_to_y[i]] is the nearest neighbor to x[i] in y).
+                    corrs_y_to_x is similar to corrs_x_to_y but with x and y reversed.
+        max_points_per_leaf : The maximum number of points per leaf node in the KD tree used by this function.
+                            Default is 10.
+        p_norm : Which norm to use. p_norm can be any real number, inf (for the max norm) -inf (for the min norm),
+                0 (for sum(x != 0))
+    Returns:
+        The chamfer distance between x an dy.
+        If return_index is set, then this function returns a tuple (chamfer_dist, corrs_x_to_y, corrs_y_to_x) where
+        corrs_x_to_y and corrs_y_to_x are described above.
+    """
+
+    dists_x_to_y, corrs_x_to_y = pcu.k_nearest_neighbors(
+        x, y, k=1, squared_distances=False, max_points_per_leaf=max_points_per_leaf
+    )
+    dists_y_to_x, corrs_y_to_x = pcu.k_nearest_neighbors(
+        y, x, k=1, squared_distances=False, max_points_per_leaf=max_points_per_leaf
+    )
+
+    dists_x_to_y = np.linalg.norm(x[corrs_y_to_x] - y, axis=-1, ord=p_norm).mean()
+    dists_y_to_x = np.linalg.norm(y[corrs_x_to_y] - x, axis=-1, ord=p_norm).mean()
+
+    Comp = np.mean(dists_x_to_y)
+    Acc = np.mean(dists_y_to_x)
+    cham_dist = Comp + Acc
+
+    if return_index:
+        return cham_dist, corrs_x_to_y, corrs_y_to_x
+
+    return cham_dist, Acc, Comp
+
+
+def compute_chamfer_distance(pred_sampled, gt_points):
+    """
+    Compute chamfer distance between predicted and ground truth points.
+
+    Args:
+        pred_sampled (numpy.ndarray): Predicted point cloud.
+        gt_points (numpy.ndarray): Ground truth points.
+
+    Returns:
+        float: Chamfer distance.
+    """
+    chamfer_dist, acc, comp = chamfer_distance(pred_sampled, gt_points)
+    return chamfer_dist, acc, comp
+
+
+def f_score(precision, recall):
+    """
+    Compute F-score.
+
+    Args:
+        precision (float): Precision.
+        recall (float): Recall.
+
+    Returns:
+        float: F-score.
+    """
+    return 2 * precision * recall / (precision + recall)
+
+
+def compute_precision_recall_IOU(
+    pred_sampled, gt_points, metrics, thresh_list=[0.02], edge_type="all"
+):
+    """
+    Compute precision, recall, F-score, and IOU.
+
+    Args:
+        pred_sampled (numpy.ndarray): Predicted point cloud.
+        gt_points (numpy.ndarray): Ground truth points.
+        metrics (dict): Dictionary to store metrics.
+
+    Returns:
+        dict: Updated metrics.
+    """
+    if edge_type == "all":
+        for thresh in thresh_list:
+            dists_a_to_b, _ = pcu.k_nearest_neighbors(
+                pred_sampled, gt_points, k=1
+            )  # k closest points (in pts_b) for each point in pts_a
+            correct_pred = np.sum(dists_a_to_b < thresh)
+            precision = correct_pred / len(dists_a_to_b)
+            metrics[f"precision_{thresh}"].append(precision)
+
+            dists_b_to_a, _ = pcu.k_nearest_neighbors(gt_points, pred_sampled, k=1)
+            correct_gt = np.sum(dists_b_to_a < thresh)
+            recall = correct_gt / len(dists_b_to_a)
+            metrics[f"recall_{thresh}"].append(recall)
+
+            fscore = 2 * precision * recall / (precision + recall)
+            metrics[f"fscore_{thresh}"].append(fscore)
+
+            intersection = min(correct_pred, correct_gt)
+            union = (
+                len(dists_a_to_b) + len(dists_b_to_a) - max(correct_pred, correct_gt)
+            )
+
+            IOU = intersection / union
+            metrics[f"IOU_{thresh}"].append(IOU)
+        return metrics
+    else:
+        correct_gt_list = []
+        correct_pred_list = []
+        _, acc, comp = compute_chamfer_distance(pred_sampled, gt_points)
+        for thresh in thresh_list:
+            dists_b_to_a, _ = pcu.k_nearest_neighbors(gt_points, pred_sampled, k=1)
+            correct_gt = np.sum(dists_b_to_a < thresh)
+            num_gt = len(dists_b_to_a)
+            correct_gt_list.append(correct_gt)
+            dists_a_to_b, _ = pcu.k_nearest_neighbors(pred_sampled, gt_points, k=1)
+            correct_pred = np.sum(dists_a_to_b < thresh)
+            correct_pred_list.append(correct_pred)
+            num_pred = len(dists_a_to_b)
+
+        return correct_gt_list, num_gt, correct_pred_list, num_pred, acc, comp
+
+
+# def get_gt_points(
+#     scan_name,
+#     edge_type="all",
+#     interval=0.005,
+#     return_direction=False,
+#     data_base_dir=None,
+# ):
+#     """
+#     Get ground truth points from a dataset.
+
+#     Args:
+#         name (str): Name of the dataset.
+
+#     Returns:
+#         numpy.ndarray: Raw and processed ground truth points.
+#     """
+#     objs_dir = os.path.join(data_base_dir, "obj")
+#     obj_names = os.listdir(objs_dir)
+#     obj_names.sort()
+#     index_obj_names = {}
+#     for obj_name in obj_names:
+#         index_obj_names[obj_name[:8]] = obj_name
+
+#     json_feats_path = os.path.join(data_base_dir, "chunk_0000_feats.json")
+#     with open(json_feats_path, "r") as f:
+#         json_data_feats = json.load(f)
+#     json_stats_path = os.path.join(data_base_dir, "chunk_0000_stats.json")
+#     with open(json_stats_path, "r") as f:
+#         json_data_stats = json.load(f)
+
+#     # get the normalize scale to help align the nerf points and gt points
+#     [
+#         x_min,
+#         y_min,
+#         z_min,
+#         x_max,
+#         y_max,
+#         z_max,
+#         x_range,
+#         y_range,
+#         z_range,
+#     ] = json_data_stats[scan_name]["bbox"]
+#     scale = 1 / max(x_range, y_range, z_range)
+#     poi_center = (
+#         np.array([((x_min + x_max) / 2), ((y_min + y_max) / 2), ((z_min + z_max) / 2)])
+#         * scale
+#     )
+#     set_location = [0.5, 0.5, 0.5] - poi_center  # based on the rendering settings
+#     obj_path = os.path.join(objs_dir, index_obj_names[scan_name])
+
+#     with open(obj_path, encoding="utf-8") as file:
+#         data = file.readlines()
+
+#     vertices_obj = [each.split(" ") for each in data if each.split(" ")[0] == "v"]
+#     vertices_xyz = [
+#         [float(v[1]), float(v[2]), float(v[3].replace("\n", ""))] for v in vertices_obj
+#     ]
+
+#     edge_pts = []
+#     edge_pts_raw = []
+#     edge_pts_direction = []
+#     rename = {
+#         "BSpline": "curve",
+#         "Circle": "curve",
+#         "Ellipse": "curve",
+#         "Line": "line",
+#     }
+#     for each_curve in json_data_feats[scan_name]:
+#         if edge_type != "all" and rename[each_curve["type"]] != edge_type:
+#             continue
+
+#         if each_curve["sharp"]:  # each_curve["type"]: BSpline, Line, Circle
+#             each_edge_pts = [vertices_xyz[i] for i in each_curve["vert_indices"]]
+#             edge_pts_raw += each_edge_pts
+
+#             gt_sampling = []
+#             each_edge_pts = np.array(each_edge_pts)
+#             for index in range(len(each_edge_pts) - 1):
+#                 next = each_edge_pts[index + 1]
+#                 current = each_edge_pts[index]
+#                 num = int(np.linalg.norm(next - current) // interval)
+#                 linspace = np.linspace(0, 1, num)
+#                 gt_sampling.append(
+#                     linspace[:, None] * current + (1 - linspace)[:, None] * next
+#                 )
+
+#                 if return_direction:
+#                     direction = (next - current) / np.linalg.norm(next - current)
+#                     edge_pts_direction.extend([direction] * num)
+#             each_edge_pts = np.concatenate(gt_sampling).tolist()
+#             edge_pts += each_edge_pts
+
+#     if len(edge_pts_raw) == 0:
+#         return None, None, None
+
+#     edge_pts_raw = np.array(edge_pts_raw) * scale + set_location
+#     edge_pts = np.array(edge_pts) * scale + set_location
+#     edge_pts_direction = np.array(edge_pts_direction)
+
+#     return (
+#         edge_pts_raw.astype(np.float32),
+#         edge_pts.astype(np.float32),
+#         edge_pts_direction,
+#     )
+
+# def bezier_curve_length(control_points, num_samples):
+#     def binomial_coefficient(n, i):
+#         return math.factorial(n) // (math.factorial(i) * math.factorial(n - i))
+
+#     def derivative_bezier(t):
+#         n = len(control_points) - 1
+#         point = np.array([0.0, 0.0, 0.0])
+#         for i, (p1, p2) in enumerate(zip(control_points[:-1], control_points[1:])):
+#             point += (
+#                 n
+#                 * binomial_coefficient(n - 1, i)
+#                 * (1 - t) ** (n - 1 - i)
+#                 * t**i
+#                 * (np.array(p2) - np.array(p1))
+#             )
+#         return point
+
+#     def simpson_integral(a, b, num_samples):
+#         h = (b - a) / num_samples
+#         sum1 = sum(
+#             np.linalg.norm(derivative_bezier(a + i * h))
+#             for i in range(1, num_samples, 2)
+#         )
+#         sum2 = sum(
+#             np.linalg.norm(derivative_bezier(a + i * h))
+#             for i in range(2, num_samples - 1, 2)
+#         )
+#         return (
+#             (
+#                 np.linalg.norm(derivative_bezier(a))
+#                 + 4 * sum1
+#                 + 2 * sum2
+#                 + np.linalg.norm(derivative_bezier(b))
+#             )
+#             * h
+#             / 3
+#         )
+
+#     # Compute the length of the 3D Bezier curve using composite Simpson's rule
+#     length = 0.0
+#     for i in range(num_samples):
+#         t0 = i / num_samples
+#         t1 = (i + 1) / num_samples
+#         length += simpson_integral(t0, t1, num_samples)
+
+#     return length
+
+# def load_from_json(filename: Path):
+#     """Load a dictionary from a JSON filename."""
+#     assert filename.suffix == ".json"
+#     with open(filename, encoding="UTF-8") as file:
+#         return json.load(file)

--- a/evaluation/gen_GT_curve_points.py
+++ b/evaluation/gen_GT_curve_points.py
@@ -1,0 +1,123 @@
+import os
+import numpy as np
+import matplotlib
+import matplotlib.pyplot as plt
+import colorsys
+import random
+import json
+
+def visualize_gt(all_gt_points, name, save_fig=False, show_fig=True):
+    ax = plt.figure(dpi=120).add_subplot(projection='3d')
+    x = [k[0] for k in all_gt_points]
+    y = [k[1] for k in all_gt_points]
+    z = [k[2] for k in all_gt_points]
+    ax.scatter(x, y, z, c='g', marker='o', s=0.5, linewidth=1, alpha=1, cmap='spectral')
+
+    # ax.axis('auto')
+    plt.axis('off')
+    # plt.xlabel("X axis")
+    # plt.ylabel("Y axis")
+
+    with open(os.path.join(vis_gt_dir, name + ".txt"), "w") as file:
+        for k in all_gt_points:
+            file.write('{}'.format(k[0]))
+            file.write('\t{}'.format(k[1]))
+            file.write('\t{}\n'.format(k[2]))
+
+    ax.view_init(azim=60, elev=60)
+    range_size = [0, 1]
+    ax.set_zlim3d(range_size[0], range_size[1])
+    plt.axis([range_size[0], range_size[1], range_size[0], range_size[1]])
+    if save_fig:
+        plt.savefig(os.path.join(vis_gt_dir, name + ".png"), bbox_inches='tight')
+    if show_fig:
+        plt.show()
+
+def get_gt_points(name, base_dir):
+    objs_dir = os.path.join(base_dir, "obj")
+    obj_names = os.listdir(objs_dir)
+    obj_names.sort()
+    index_obj_names = {}
+    for obj_name in obj_names:
+        index_obj_names[obj_name[:8]] = obj_name
+
+    json_feats_path = os.path.join(base_dir, "chunk_0000_feats.json")
+    with open(json_feats_path, 'r') as f:
+        json_data_feats = json.load(f)
+    json_stats_path = os.path.join(base_dir, "chunk_0000_stats.json")
+    with open(json_stats_path, 'r') as f:
+        json_data_stats = json.load(f)
+
+    # get the normalize scale to help align the nerf points and gt points
+    [x_min, y_min, z_min, x_max, y_max, z_max, x_range, y_range, z_range] = json_data_stats[name]["bbox"]
+    scale = 1 / max(x_range, y_range, z_range)
+    # print("normalize scale:", scale)
+    poi_center = np.array([((x_min + x_max) / 2), ((y_min + y_max) / 2), ((z_min + z_max) / 2)]) * scale
+    # print("poi:", poi_center)
+    set_location = [0.5, 0.5, 0.5] - poi_center  # based on the rendering settings
+
+    obj_path = os.path.join(objs_dir, index_obj_names[name])
+    with open(obj_path, encoding='utf-8') as file:
+        data = file.readlines()
+    vertices_obj = [each.split(' ') for each in data if each.split(' ')[0] == 'v']
+    vertices_xyz = [[float(v[1]), float(v[2]), float(v[3].replace('\n', ''))] for v in vertices_obj]
+
+    edge_pts = []
+    edge_pts_raw = []
+    for each_curve in json_data_feats[name]:
+        #> Take all curves, regardless whether any of them is 'sharp' or not
+        # if each_curve['sharp']:
+        each_edge_pts = [vertices_xyz[i] for i in each_curve['vert_indices']]
+        edge_pts_raw += each_edge_pts
+
+        gt_sampling = []
+        each_edge_pts = np.array(each_edge_pts)
+        for index in range(len(each_edge_pts) - 1):
+            next = each_edge_pts[index + 1]
+            current = each_edge_pts[index]
+            num = int(np.linalg.norm(next - current) // 0.01)
+            linspace = np.linspace(0, 1, num)
+            gt_sampling.append(linspace[:, None] * current + (1 - linspace)[:, None] * next)
+        each_edge_pts = np.concatenate(gt_sampling).tolist()
+        edge_pts += each_edge_pts
+
+
+    edge_pts_raw = np.array(edge_pts_raw) * scale + set_location
+    edge_pts = np.array(edge_pts) * scale + set_location
+
+    return edge_pts_raw.astype(np.float32), edge_pts.astype(np.float32)
+
+#> Define the root paths and base directory
+root_dir = "/gpfs/data/bkimia/cchien3/Qiwu_Edge_Grouping/3D_Edge_Sketch_and_Grouping/"
+base_dir = root_dir + "ABC_NEF_obj"
+objs_dir = os.path.join(base_dir, "obj")
+obj_names = os.listdir(objs_dir)
+obj_names.sort()
+sorted_obj_names = np.array(obj_names)
+for i, obj_name in enumerate(obj_names):
+    sorted_obj_names[i] = obj_name[:8]
+
+#> Define the path for saving figures
+vis_gt_dir = root_dir + "evaluations/gt_curve_points"
+os.makedirs(vis_gt_dir, exist_ok=True)
+desired_obj = "00004605"
+do_only_on_desired_obj = True
+
+if do_only_on_desired_obj == True:
+    #> find the desired object in the sorted_obj_names
+    for i, name in enumerate(sorted_obj_names):
+        if name == desired_obj:
+            break
+
+    print("-" * 50)
+    print("processing:", i, ", name:", name)
+
+    gt_points_raw, gt_points = get_gt_points(name, base_dir)
+    visualize_gt(gt_points, name, save_fig=True, show_fig=True)
+else:
+    for i, name in enumerate(sorted_obj_names):
+        print("-" * 50)
+        print("processing:", i, ", name:", name)
+
+        gt_points_raw, gt_points = get_gt_points(name, base_dir)
+        visualize_gt(gt_points, name, save_fig=True, show_fig=False)

--- a/evaluation/requirements.txt
+++ b/evaluation/requirements.txt
@@ -1,0 +1,4 @@
+opencv-python==4.9.0.80
+scipy==1.10.1
+open3d==0.18.0
+point_cloud_utils==0.30.4

--- a/visualization/plot_curves.m
+++ b/visualization/plot_curves.m
@@ -1,0 +1,86 @@
+
+%% Visualize 3D Curves from Connectivity Graph
+% This script visualizes the curves extracted from the connectivity graph
+
+% Define the folder path
+data_folder_name = 'outputs';
+data_folder_path = fullfile(fileparts(mfilename('fullpath')), '..', data_folder_name);
+curve_file = fullfile(data_folder_path, 'curves_from_connectivity_graph.txt');
+
+% Read the data
+fileID = fopen(curve_file, 'r');
+if fileID == -1
+    error('Could not open file: %s', curve_file);
+end
+
+% Skip the header lines
+header = fgetl(fileID);
+header2 = fgetl(fileID);
+
+% Initialize data structures
+curve_data = [];
+curve_ids = [];
+node_indices = [];
+current_curve_id = -1;
+
+% Read line by line
+line = fgetl(fileID);
+while ischar(line)
+    % Skip empty lines
+    if ~isempty(line)
+        data = sscanf(line, '%f');
+        if length(data) >= 8
+            curve_id = data(1);
+            node_idx = data(2);
+            x = data(3);
+            y = data(4);
+            z = data(5);
+            dir_x = data(6);
+            dir_y = data(7);
+            dir_z = data(8);
+            
+            curve_data = [curve_data; x, y, z, dir_x, dir_y, dir_z];
+            curve_ids = [curve_ids; curve_id];
+            node_indices = [node_indices; node_idx];
+            
+            if curve_id ~= current_curve_id
+                current_curve_id = curve_id;
+            end
+        end
+    end
+    line = fgetl(fileID);
+end
+fclose(fileID);
+
+% Get unique curve IDs
+unique_curves = unique(curve_ids);
+num_curves = length(unique_curves);
+
+fprintf('Found %d curves\n', num_curves);
+
+% Create figure
+figure;
+hold on;
+
+% Define a fixed set of 20 distinct colors that will repeat
+fixed_colors = jet(20);
+
+% Plot each curve
+for i = 1:num_curves
+    curve_idx = curve_ids == unique_curves(i);
+    points = curve_data(curve_idx, 1:3);
+    
+    % Use modulo to cycle through the 20 colors
+    color_idx = mod(i-1, 20) + 1;
+    color = fixed_colors(color_idx, :);
+    
+    plot3(points(:, 1), points(:, 2), points(:, 3), '-', 'LineWidth', 2, 'Color', color);
+end
+
+title('3D Curves from Connectivity Graph');
+axis off;
+axis equal;
+view(3); 
+set(gcf, 'color', 'w');
+ax = gca;
+ax.Clipping = "off";


### PR DESCRIPTION
Several updates have been made by Qiwu and me:
- 3D edge connectivity graph has been integrated from the test function to the main edge_mapping code.
- The output 3D edge/curve points can now be evaluated using the ground-truth curve points of the ABC-NEF dataset using the evaluation scripts written in Python
- Update README to include the evaluation instructions