### PR TITLE
fix the issue when writing edge location and orientation into a file

### DIFF
--- a/Edge_Reconst/EdgeSketch_Core.cpp
+++ b/Edge_Reconst/EdgeSketch_Core.cpp
@@ -978,7 +978,7 @@ void EdgeSketch_Core::Stack_3D_Edges() {
     tangents_file.close();
 #endif
 
-    Eigen::MatrixXd mvt_3d_edges = NViewsTrian::mvt(hyp01_view_indx, hyp02_view_indx, Scene_Name);
+    Eigen::MatrixXd mvt_3d_edges = NViewsTrian::mvt(hyp01_view_indx, hyp02_view_indx, Scene_Name, Edge_Detection_Init_Thresh, Edge_Detection_Final_Thresh);
 
     //> Concatenate reconstructed 3D edges
     if (all_3D_Edges.rows() == 0) {

--- a/Edge_Reconst/mvt.cpp
+++ b/Edge_Reconst/mvt.cpp
@@ -304,23 +304,26 @@ void writeTangentFile(const std::string& outputTangentFilePath, const std::vecto
 /////////////////////////////////// 3D RECONSTRUCTION ///////////////////////////////////////////////////////
 
 
-Eigen::MatrixXd mvt(int hyp1, int hyp2, std::string Scene_Name) {
+Eigen::MatrixXd mvt(int hyp1, int hyp2, std::string Scene_Name, int init_toed_thresh, int final_toed_thresh) {
 
     std::string basePath = "../../outputs/";
     std::string filePath = basePath + "paired_edges_final_" + std::to_string(hyp1) + "_" + std::to_string(hyp2) + ".txt";
     std::string outputFilePath = basePath + "triangulated_3D_edges_ABC-NEF_" + Scene_Name + "_hypo1_" + 
                                 std::to_string(hyp1) + "_hypo2_" + std::to_string(hyp2) + 
-                                "_t4to4_delta03_theta15.000000_N4.txt";
+                                "_t" + std::to_string(init_toed_thresh) + "to" + std::to_string(final_toed_thresh) 
+                                + "_delta03_theta15.000000_N4.txt";
     std::string points3DFile = basePath + "3D_edges_ABC-NEF_" + Scene_Name + "_hypo1_" + 
                             std::to_string(hyp1) + "_hypo2_" + std::to_string(hyp2) + 
-                            "_t4to4_delta03_theta15.000000_N4.txt";
+                            "_t" + std::to_string(init_toed_thresh) + "to" + std::to_string(final_toed_thresh) 
+                            + "_delta03_theta15.000000_N4.txt";
     std::string tangentFilePath = basePath + "3D_tangents_ABC-NEF_" + Scene_Name + "_hypo1_" + 
                             std::to_string(hyp1) + "_hypo2_" + std::to_string(hyp2) + 
-                            "_t4to4_delta03_theta15.000000_N4.txt";
+                            "_t" + std::to_string(init_toed_thresh) + "to" + std::to_string(final_toed_thresh) 
+                            + "_delta03_theta15.000000_N4.txt";
     std::string outputTangentFilePath = "../../outputs/updated_tangents.txt"; 
     std::vector<Eigen::Vector3d> points3D;
 
-    ////////////////////// Read 3D points from the file //////////////////////
+    //////////////////// Read 3D points from the file //////////////////////
     std::ifstream points3DStream(points3DFile);
     if (!points3DStream.is_open()) {
         std::cerr << "[Error]: Failed to open file: " << points3DFile << std::endl;
@@ -461,10 +464,8 @@ Eigen::MatrixXd mvt(int hyp1, int hyp2, std::string Scene_Name) {
         gammaIndex++;
     }
 
-    //outFile.flush();
     outFile.close();
     writeTangentFile(outputTangentFilePath, updatedTangents);
-   // std::cout << "gammaIndex before resize: " << gammaIndex << std::endl;
 
     GammaMatrix.conservativeResize(3, gammaIndex);  // Resize to keep only valid columns
 

--- a/Edge_Reconst/mvt.hpp
+++ b/Edge_Reconst/mvt.hpp
@@ -39,7 +39,7 @@ void loadRTMatrices(const std::string& R_file_path, const std::string& T_file_pa
 std::vector<std::vector<EdgeData>> parseFile(const std::string& filePath);
 std::vector<Eigen::Vector3d> readTangentFile(const std::string& tangentFilePath);
 void writeTangentFile(const std::string& outputTangentFilePath, const std::vector<Eigen::Vector3d>& tangents);
-Eigen::MatrixXd mvt(int hyp1, int hyp2, std::string Scene_Name);
+Eigen::MatrixXd mvt(int hyp1, int hyp2, std::string Scene_Name, int init_toed_thresh, int final_toed_thresh);
 void grouped_mvt(const std::vector<std::vector<EdgeMapping::SupportingEdgeData>>& all_groups, const std::string& outputFilePath, const std::string& tangentOutputFilePath);
 
 } // namespace NViewsTrian


### PR DESCRIPTION
Pass variables to the function to rectify the file name when writing 3D edge locations and orientations