### PR TITLE
In preperation for uplifting 2D edge links to 3D edge neighborhood graph

### DIFF
--- a/Edge_Reconst/EdgeSketch_Core.cpp
+++ b/Edge_Reconst/EdgeSketch_Core.cpp
@@ -826,6 +826,8 @@ void EdgeSketch_Core::Finalize_Edge_Pairs_and_Reconstruct_3D_Edges(std::shared_p
         Eigen::MatrixXd edgel_HYPO1   = Edges_HYPO1.row(int(paired_edge_final(pair_idx,0)));  //> edge index in hypo 1
         Eigen::MatrixXd edgel_HYPO2   = Edges_HYPO2.row(int(paired_edge_final(pair_idx,1)));  //> edge index in hypo 2
         Eigen::MatrixXd HYPO2_idx_raw = Edges_HYPO2.row(int(paired_edge_final(pair_idx,1)));
+        int hypo1_idx = int(paired_edge_final(pair_idx,0));
+        int hypo2_idx = int(paired_edge_final(pair_idx,1));
 
         Eigen::MatrixXd edgels_HYPO2_corrected = PairHypo->edgelsHYPO2correct_post_validation(edgel_HYPO2, edgel_HYPO1, F21, F12, HYPO2_idx_raw);
 
@@ -869,8 +871,8 @@ void EdgeSketch_Core::Finalize_Edge_Pairs_and_Reconstruct_3D_Edges(std::shared_p
         
         Eigen::Vector3d edge_uncorrected_hyp1 = edgel_HYPO1.block<1,3>(0,0).transpose();
         Eigen::Vector3d edge_uncorrected_hyp2 = edgel_HYPO2.block<1,3>(0,0).transpose();
-        edgeMapping->add3DToSupportingEdgesMapping(edge_pt_3D_world, tangents_3D_world, pt_H1, edge_uncorrected_hyp1, hyp01_view_indx, All_R[hyp01_view_indx], All_T[hyp01_view_indx]);
-        edgeMapping->add3DToSupportingEdgesMapping(edge_pt_3D_world, tangents_3D_world, pt_H2, edge_uncorrected_hyp2, hyp02_view_indx, All_R[hyp02_view_indx], All_T[hyp02_view_indx]);
+        edgeMapping->add3DToSupportingEdgesMapping(edge_pt_3D_world, tangents_3D_world, pt_H1, edge_uncorrected_hyp1, hyp01_view_indx, hypo1_idx, All_R[hyp01_view_indx], All_T[hyp01_view_indx]);
+        edgeMapping->add3DToSupportingEdgesMapping(edge_pt_3D_world, tangents_3D_world, pt_H2, edge_uncorrected_hyp2, hyp02_view_indx, hypo2_idx, All_R[hyp02_view_indx], All_T[hyp02_view_indx]);
 
         ///////////////////////////////// Add support from validation views /////////////////////////////////
         std::vector<std::pair<int, Eigen::Vector2d>> validation_support_edges;
@@ -931,7 +933,7 @@ void EdgeSketch_Core::Finalize_Edge_Pairs_and_Reconstruct_3D_Edges(std::shared_p
                     validation_support_edges.emplace_back(val_idx, supporting_edge);
                     //> Qiwu: Add the supporting edge to the edgeMapping for the 3D edge
                     //edgeMapping->add3DToSupportingEdgesMapping(edge_pt_3D_world, supporting_edge, val_idx, All_R[val_idx], All_T[val_idx]);
-                    edgeMapping->add3DToSupportingEdgesMapping(edge_pt_3D_world, tangents_3D_world, corrected_val, supporting_edge_mapping, val_idx, All_R[val_idx], All_T[val_idx]);
+                    edgeMapping->add3DToSupportingEdgesMapping(edge_pt_3D_world, tangents_3D_world, corrected_val, supporting_edge_mapping, val_idx, support_idx, All_R[val_idx], All_T[val_idx]);
                 }
             }
             val_indx_in_paired_edge_array++;

--- a/Edge_Reconst/PairEdgeHypo.cpp
+++ b/Edge_Reconst/PairEdgeHypo.cpp
@@ -354,8 +354,10 @@ namespace PairEdgeHypothesis {
             double a_edgeH2 = tan(edgels_HYPO2(idx_hypo2,2)); //tan(theta2)
             double b_edgeH2 = -1;
             double c_edgeH2 = -(a_edgeH2*edgels_HYPO2(idx_hypo2,0)-edgels_HYPO2(idx_hypo2,1)); //−(a⋅x2−y2)
-            double x_intersection = ( (b1_line * c_edgeH2 - b_edgeH2 * c1_line) / (a1_line * b_edgeH2 - a_edgeH2 * b1_line) + edgels_HYPO2(idx_hypo2,0) ) / 2;
-            double y_intersection = ( (c1_line * a_edgeH2 - c_edgeH2 * a1_line) / (a1_line * b_edgeH2 - a_edgeH2 * b1_line) + edgels_HYPO2(idx_hypo2,1) ) / 2;
+            // double x_intersection = ( (b1_line * c_edgeH2 - b_edgeH2 * c1_line) / (a1_line * b_edgeH2 - a_edgeH2 * b1_line) + edgels_HYPO2(idx_hypo2,0) ) / 2;
+            // double y_intersection = ( (c1_line * a_edgeH2 - c_edgeH2 * a1_line) / (a1_line * b_edgeH2 - a_edgeH2 * b1_line) + edgels_HYPO2(idx_hypo2,1) ) / 2;
+            double x_intersection = (b1_line * c_edgeH2 - b_edgeH2 * c1_line) / (a1_line * b_edgeH2 - a_edgeH2 * b1_line);
+            double y_intersection = (c1_line * a_edgeH2 - c_edgeH2 * a1_line) / (a1_line * b_edgeH2 - a_edgeH2 * b1_line);
             double dist_diff_edg2    = sqrt((x_intersection - edgels_HYPO2(idx_hypo2,0))*(x_intersection - edgels_HYPO2(idx_hypo2,0))+(y_intersection -  edgels_HYPO2(idx_hypo2,1))*(y_intersection - edgels_HYPO2(idx_hypo2,1)));
             
 

--- a/Edge_Reconst/definitions.h
+++ b/Edge_Reconst/definitions.h
@@ -13,6 +13,7 @@
 //> Edge graph pruning parameters
 #define PRUNE_3D_EDGE_GRAPH_LAMBDA1     (0.5)
 #define PRUNE_3D_EDGE_GRAPH_LAMBDA2     (0.5)
+#define PRUNE_3D_EDGE_GRAPH_LAMBDA3     (0.5)
 #define PRUNE_BY_PROJ_PROX_THRESH       (6)     //> in pixels
 #define PRUNE_BY_PROJ_ORIE_THRESH       (60)    //> in degrees
 

--- a/Edge_Reconst/edge_mapping.hpp
+++ b/Edge_Reconst/edge_mapping.hpp
@@ -22,14 +22,6 @@ struct HashEigenVector3d {
     }
 };
 
-// // Hash function for Eigen::Vector2d to use in unordered_map
-// struct HashEigenVector2d {
-//     std::size_t operator()(const Eigen::Vector2d& vec) const {
-//         std::size_t h1 = std::hash<double>()(vec(0));
-//         std::size_t h2 = std::hash<double>()(vec(1));
-//         return h1 ^ (h2 << 1); // Combine hashes
-//     }
-// };
 
 
 struct FuzzyVector3dEqual {
@@ -37,6 +29,8 @@ struct FuzzyVector3dEqual {
         return (a - b).norm() < 1e-6;
     }
 };
+
+
 
 struct FuzzyVector3dPairEqual {
     bool operator()(const std::pair<Eigen::Vector3d, Eigen::Vector3d>& a,
@@ -65,6 +59,7 @@ public:
         Eigen::Vector2d edge;
         Eigen::Vector3d edge_uncorrected;
         int image_number;
+        int edge_idx;
         Eigen::Matrix3d rotation;
         Eigen::Vector3d translation;
         Eigen::Vector3d tangents_3D_world;
@@ -87,6 +82,7 @@ public:
     struct Uncorrected2DEdgeKey {
         Eigen::Vector3d edge_uncorrected;
         int image_number;
+        int edge_idx;
         Eigen::Matrix3d rotation;
         Eigen::Vector3d translation;
 
@@ -151,6 +147,7 @@ public:
                                        const Eigen::Vector2d &supporting_edge, 
                                        const Eigen::Vector3d &supporting_edge_uncorrected, 
                                        int image_number,
+                                       int edge_idx,
                                        const Eigen::Matrix3d &rotation,
                                        const Eigen::Vector3d &translation);
 
@@ -163,12 +160,12 @@ public:
     using EdgeNodeList = std::vector<std::unique_ptr<EdgeNode>>;
 
 
-    std::vector<std::vector<SupportingEdgeData>> findMergable2DEdgeGroups(const std::vector<Eigen::Matrix3d> all_R,const std::vector<Eigen::Vector3d> all_T, const Eigen::Matrix3d K, const int Num_Of_Total_Imgs);
+    std::vector<std::vector<SupportingEdgeData>> findMergable2DEdgeGroups(const std::vector<Eigen::Matrix3d> all_R,const std::vector<Eigen::Vector3d> all_T, const Eigen::Matrix3d K, const int Num_Of_Total_Imgs,  const std::vector<Eigen::MatrixXd> All_Edgels);
     
     std::unordered_map<Eigen::Vector3d, std::vector<SupportingEdgeData>, HashEigenVector3d> edge_3D_to_supporting_edges;
     std::unordered_map<Uncorrected2DEdgeKey, std::vector<Uncorrected2DEdgeMappingData>, HashUncorrected2DEdgeKey> map_Uncorrected2DEdge_To_SupportingData();
     std::unordered_map<std::pair<Eigen::Vector3d, Eigen::Vector3d>, int, HashEigenVector3dPair, FuzzyVector3dPairEqual>
-    build3DEdgeWeightedGraph(const std::unordered_map<Uncorrected2DEdgeKey, std::vector<Uncorrected2DEdgeMappingData>, HashUncorrected2DEdgeKey>& uncorrected_map);
+    build3DEdgeWeightedGraph(const std::unordered_map<Uncorrected2DEdgeKey, std::vector<Uncorrected2DEdgeMappingData>, HashUncorrected2DEdgeKey>& uncorrected_map, const std::vector<Eigen::MatrixXd> All_Edgels);
     //EdgeNodeList createEdgeNodesFromEdges(const std::vector<Eigen::Vector3d>& locations, const std::unordered_map<std::pair<Eigen::Vector3d, Eigen::Vector3d>, int, HashEigenVector3dPair, FuzzyVector3dPairEqual>& pruned_graph);
     //EdgeNodeList createEdgeNodesFromFiles(const std::string& points_file, const std::string& tangents_file, const std::string& connections_file);
 

--- a/Edge_Reconst/file_reader.cpp
+++ b/Edge_Reconst/file_reader.cpp
@@ -10,6 +10,7 @@ file_reader::file_reader( std::string dataset_path, std::string dataset_name, st
   dataset_name_sequence_path = dataset_path + dataset_name + "/" + scene_name;
 
   Edge_File_Path_First_Half = dataset_name_sequence_path + "/Edges/Edge_";
+  Curvelet_File_Path_First_Half = dataset_name_sequence_path + "/curvelets/Curvelets_";
   Rmatrix_File_Path = dataset_name_sequence_path + "/RnT/R_matrix.txt";
   Tmatrix_File_Path = dataset_name_sequence_path + "/RnT/T_matrix.txt";
   Kmatrix_File_Path = dataset_name_sequence_path + "/RnT/K_matrix.txt";
@@ -62,6 +63,38 @@ Eigen::MatrixXd file_reader::read_Edgels_Of_a_File( int file_idx, int thresh_EDG
   }
   Edge_File.close();
   return Edgels;
+}
+
+//> Read all edge curvelets
+void file_reader::read_All_Curvelets( std::vector<EdgeCurvelet> &All_Curvelets, int thresh_EDG ) {
+  int file_idx = 0;
+  All_Curvelets.clear();
+
+  //> Looping over all frames and read corresponding edgels
+  while( file_idx < Dataset_Total_Num_Of_Images ) 
+  {
+    std::string Curvelet_File_Path = Curvelet_File_Path_First_Half + std::to_string(file_idx) + "_t" + std::to_string(thresh_EDG) + ".txt";
+    std::fstream Curvelet_File;
+    Curvelet_File.open(Curvelet_File_Path, std::ios_base::in);
+    if (!Curvelet_File) {
+      LOG_FILE_ERROR(Curvelet_File_Path); 
+      exit(1);
+    }
+    else {
+      int rd_data_anchor, rd_data_chain1, rd_data_chain2;
+      while (Curvelet_File >> rd_data_anchor >> rd_data_chain1 >> rd_data_chain2 ) {
+        EdgeCurvelet curvelet;
+        curvelet.image_number = file_idx;
+        curvelet.self_edge_index = rd_data_anchor;
+        curvelet.neighbor_edge_index = rd_data_chain1;
+        All_Curvelets.push_back(curvelet);
+      }
+    }
+    file_idx++;    
+  }
+#if SHOW_DATA_LOADING_INFO
+  std::cout << "All edge curvelets are loaded successfully" << std::endl;
+#endif
 }
 
 //> Read rotation matrices of all cameras

--- a/Edge_Reconst/file_reader.hpp
+++ b/Edge_Reconst/file_reader.hpp
@@ -8,12 +8,20 @@
 #include <Eigen/Dense>
 #include "definitions.h"
 
+struct EdgeCurvelet {
+    int image_number;
+    int self_edge_index;
+    int neighbor_edge_index;
+};
+
 class file_reader{
 
 public:
     file_reader( std::string, std::string, std::string, int );
     void read_All_Edgels( std::vector<Eigen::MatrixXd> &All_Edgels, int thresh_EDG );
     Eigen::MatrixXd read_Edgels_Of_a_File( int file_idx, int thresh_EDG );
+    void read_All_Curvelets( std::vector<EdgeCurvelet> &All_Curvelets, int thresh_EDG );
+    void read_curvelets_Of_a_File( EdgeCurvelet &curvelet, int file_idx, int thresh_EDG );
     void readRmatrix( std::vector<Eigen::Matrix3d> &All_R );
     void readTmatrix( std::vector<Eigen::Vector3d> &All_T );
     void readK( std::vector<Eigen::Matrix3d> &All_K );
@@ -24,6 +32,7 @@ private:
 
     //> Paths for the files
     std::string Edge_File_Path_First_Half;
+    std::string Curvelet_File_Path_First_Half;
     std::string Rmatrix_File_Path;
     std::string Tmatrix_File_Path;
     std::string Kmatrix_File_Path;

--- a/cmd/main.cpp
+++ b/cmd/main.cpp
@@ -143,7 +143,7 @@ int main(int argc, char **argv) {
   // edgeMapping->printFirst10Edges();
   std::cout << "====================================================================" << std::endl;
 
-  std::vector<std::vector<EdgeMapping::SupportingEdgeData>> all_groups = edgeMapping->findMergable2DEdgeGroups(MWV_Edge_Rec.All_R, MWV_Edge_Rec.All_T, MWV_Edge_Rec.K, MWV_Edge_Rec.Num_Of_Total_Imgs);
+  std::vector<std::vector<EdgeMapping::SupportingEdgeData>> all_groups = edgeMapping->findMergable2DEdgeGroups(MWV_Edge_Rec.All_R, MWV_Edge_Rec.All_T, MWV_Edge_Rec.K, MWV_Edge_Rec.Num_Of_Total_Imgs, MWV_Edge_Rec.All_Edgels);
   // std::string outputFilePath = "../../outputs/grouped_mvt.txt";
   // std::string outputFilePath_tangent = "../../outputs/grouped_mvt_tangent.txt";
   // NViewsTrian::grouped_mvt(all_groups, outputFilePath, outputFilePath_tangent);

--- a/test/test_functions.cpp
+++ b/test/test_functions.cpp
@@ -10,8 +10,10 @@
 
 #include "../Edge_Reconst/definitions.h"
 #include "../Edge_Reconst/util.hpp"
+#include "../Edge_Reconst/file_reader.hpp"
 
 //> Select the test
+#define TEST_READ_CURVELETS         (true)
 #define TEST_EDGE_ALIGNMENT         (true)
 #define TEST_CONNECTIVITY_GRAPH     (true)  //> TEST_EDGE_ALIGNMENT has to be true to activate this test
 #define TANGENT_COORD_TRANSFORM     (false)
@@ -25,6 +27,23 @@ struct EdgeNode {
 };
 
 using EdgeNodeList = std::vector<std::unique_ptr<EdgeNode>>;
+
+void read_curvelets() {
+    std::string Dataset_Path = "/gpfs/data/bkimia/Datasets/";
+    std::string Dataset_Name = "ABC-NEF";
+    std::string Scene_Name = "00000006";
+    int Num_Of_Total_Imgs = 50;
+    std::shared_ptr<file_reader> Load_Data = std::shared_ptr<file_reader>(new file_reader(Dataset_Path, Dataset_Name, Scene_Name, Num_Of_Total_Imgs));
+
+    std::vector<EdgeCurvelet> All_Curvelets;
+    Load_Data->read_All_Curvelets( All_Curvelets, 1 );
+    for (int i = 0; i < 100; i++) {
+        std::cout << "image number = " << All_Curvelets[i].image_number << ", " << \
+                     "anchor edge index = " << All_Curvelets[i].self_edge_index << ", " << \
+                     "neighbor edge index = " << All_Curvelets[i].neighbor_edge_index << std::endl;
+    }
+
+}
 
 std::pair<int, int> findConnectedEdges(std::vector<double> proj_neighbor) {
     if (proj_neighbor.size() < 2) {
@@ -390,6 +409,10 @@ Eigen::Matrix3d euler_to_rotation_matrix(double roll, double pitch, double yaw) 
 
 // MARK: MAIN
 int main(int argc, char **argv) {
+
+#if TEST_READ_CURVELETS
+    read_curvelets();
+#endif
 
 #if TEST_EDGE_ALIGNMENT
     //> [TEST]


### PR DESCRIPTION
The main part of the update in the code is to prepare for the completion of 3D edge neighborhood graph by uplifting 2D edge neighbor links from curvelet construction and also add edge index to all the edge structures. 
Other minor updates include: 
- use epipolar full correction instead of half correction
- add tangential distance for pruning 3D edge links in the 3D edge neighborhood graph