### PR TITLE
Fix the construction of connectivity graph, uplift 2D edge links to 3D edge neighborhood graph, and initiate a potential fix in epipolar shift correction

### DIFF
--- a/Edge_Reconst/PairEdgeHypo.cpp
+++ b/Edge_Reconst/PairEdgeHypo.cpp
@@ -218,113 +218,29 @@ namespace PairEdgeHypothesis {
         return edgels_HYPO2_corrected;
     }
 
-    // Eigen::MatrixXd pair_edge_hypothesis::edgelsHYPO2correct_post_validation(
-    //     Eigen::MatrixXd edgels_HYPO2,  Eigen::MatrixXd edgel_HYPO1, 
-    //     Eigen::Matrix3d F21, Eigen::Matrix3d F12, Eigen::MatrixXd HYPO2_idx_raw)
-    // {
-    //     int max_possible_size = edgels_HYPO2.rows();  
-    //     Eigen::MatrixXd edgels_HYPO2_corrected(0, 10);  
 
-    //     ////////////// find cofficients for tangent and epipolar line for edge 2 //////////////
-    //     Eigen::MatrixXd xy1_H1;
-    //     xy1_H1.conservativeResize(1,3);
-    //     xy1_H1(0,0) = edgel_HYPO1(0,0);
-    //     xy1_H1(0,1) = edgel_HYPO1(0,1);
-    //     xy1_H1(0,2) = 1;
-    //     Eigen::MatrixXd coeffspt1T = F21 * xy1_H1.transpose();
-    //     Eigen::MatrixXd coeffspt1  = coeffspt1T.transpose();
-    //     Eigen::MatrixXd Apixel_1   = coeffspt1.col(0);
-    //     Eigen::MatrixXd Bpixel_1   = coeffspt1.col(1);
-    //     Eigen::MatrixXd Cpixel_1   = coeffspt1.col(2);
-    //     double a1_line  = -Apixel_1(0,0)/Bpixel_1(0,0);
-    //     double b1_line  = -1;
-    //     double c1_line  = -Cpixel_1(0,0)/Bpixel_1(0,0);
-    //     double idx_correct = 0;
-    //     ////////////// find cofficients for tangent and epipolar line for edge 2 //////////////
-        
-    //     for(int idx_hypo2 = 0; idx_hypo2 < edgels_HYPO2.rows(); idx_hypo2++){
-    //         // Parameters of the line passing through hypo2 along its angle
-    //         double a_edgeH2 = tan(edgels_HYPO2(idx_hypo2,2)); //tan(theta2)
-    //         double b_edgeH2 = -1;
-    //         double c_edgeH2 = -(a_edgeH2*edgels_HYPO2(idx_hypo2,0)-edgels_HYPO2(idx_hypo2,1)); //−(a⋅x2−y2)
-    //         // double x_intersection = ( (b1_line * c_edgeH2 - b_edgeH2 * c1_line) / (a1_line * b_edgeH2 - a_edgeH2 * b1_line) + edgels_HYPO2(idx_hypo2,0) ) / 2;
-    //         // double y_intersection = ( (c1_line * a_edgeH2 - c_edgeH2 * a1_line) / (a1_line * b_edgeH2 - a_edgeH2 * b1_line) + edgels_HYPO2(idx_hypo2,1) ) / 2;
-    //         double x_intersection = ( (b1_line * c_edgeH2 - b_edgeH2 * c1_line) / (a1_line * b_edgeH2 - a_edgeH2 * b1_line) + edgels_HYPO2(idx_hypo2,0) ) / 2;
-    //         double y_intersection = ( (c1_line * a_edgeH2 - c_edgeH2 * a1_line) / (a1_line * b_edgeH2 - a_edgeH2 * b1_line) + edgels_HYPO2(idx_hypo2,1) ) / 2;
-    //         double dist_diff_edg2    = sqrt((x_intersection - edgels_HYPO2(idx_hypo2,0))*(x_intersection - edgels_HYPO2(idx_hypo2,0))+(y_intersection -  edgels_HYPO2(idx_hypo2,1))*(y_intersection - edgels_HYPO2(idx_hypo2,1)));
-            
-
-    //         ////////////// fully correct edge 1 to half-corrected hyp2's epipolar line //////////////
-    //         Eigen::MatrixXd xy1_H2;
-    //         xy1_H2.conservativeResize(1,3);
-    //         xy1_H2(0,0) = x_intersection;
-    //         xy1_H2(0,1) = y_intersection;
-    //         xy1_H2(0,2) = 1;
-    //         Eigen::MatrixXd coeffspt2T = F12 * xy1_H2.transpose();
-    //         Eigen::MatrixXd coeffspt2  = coeffspt2T.transpose();
-    //         Eigen::MatrixXd Apixel_2   = coeffspt2.col(0);
-    //         Eigen::MatrixXd Bpixel_2   = coeffspt2.col(1);
-    //         Eigen::MatrixXd Cpixel_2   = coeffspt2.col(2);
-    //         double a2_line  = -Apixel_2(0,0)/Bpixel_2(0,0);
-    //         double b2_line  = -1;
-    //         double c2_line  = -Cpixel_2(0,0)/Bpixel_2(0,0);
-    //         double a_edgeH1 = tan(edgel_HYPO1(0,2)); //tan(theta2)
-    //         double b_edgeH1 = -1;
-    //         double c_edgeH1 = -(a_edgeH1*edgel_HYPO1(0,0)-edgel_HYPO1(0,1)); //−(a⋅x2−y2)
-    //         double x_intersection_1 = ( (b2_line * c_edgeH1 - b_edgeH1 * c2_line) / (a2_line * b_edgeH1 - a_edgeH1 * b2_line) + edgel_HYPO1(0,0) ) / 2;
-    //         double y_intersection_1 = ( (c2_line * a_edgeH1 - c_edgeH1 * a2_line) / (a2_line * b_edgeH1 - a_edgeH1 * b2_line) + edgel_HYPO1(0,1) ) / 2;
-    //         double dist_diff_edg1    = sqrt((x_intersection_1 - edgel_HYPO1(0,0))*(x_intersection_1 - edgel_HYPO1(0,0))+(y_intersection_1 - edgel_HYPO1(0,1))*(y_intersection_1 - edgel_HYPO1(0,1)));
-    //         ////////////// find cofficients for tangent and epipolar line for edge 1 //////////////
-            
-    //         if (x_intersection == 0 && y_intersection == 0) {
-    //             std::cout << "WARNING: Found (0,0) intersection! idx_hypo2: " << idx_hypo2 << std::endl;
-    //         }
-    //         if (x_intersection_1 == 0 && y_intersection_1 == 0) {
-    //             std::cout << "WARNING: Found (0,0) intersection!" << std::endl;
-    //         }
-
-    //         // check if H2 edge's tangent line is almost parallal to epipolar line
-    //         double angle_edgeH2 = edgels_HYPO2(idx_hypo2,2);  // Slope of tangent line at hyp2
-    //         double m_epipolar_edg2 = -a1_line / b1_line;            // Slope of epipolar line
-    //         double angle_diff_rad_edg2 = abs(angle_edgeH2 - atan(m_epipolar_edg2));
-    //         double angle_diff_deg_edg2 = angle_diff_rad_edg2 * (180.0 / M_PI);
-    //         if (angle_diff_deg_edg2 > 180){
-    //             angle_diff_deg_edg2 -= 180;
-    //         }
-
-    //         // check if H2 edge's tangent line is almost parallal to epipolar line
-    //         double angle_edgeH1 = edgel_HYPO1(0,2);  // Slope of tangent line at hyp2
-    //         double m_epipolar_edg1 = -a2_line / b2_line;            // Slope of epipolar line
-    //         double angle_diff_rad_edg1 = abs(angle_edgeH1 - atan(m_epipolar_edg1));
-    //         double angle_diff_deg_edg1 = angle_diff_rad_edg1 * (180.0 / M_PI);
-    //         if (angle_diff_deg_edg1 > 180){
-    //             angle_diff_deg_edg1 -= 180;
-    //         }
-
-
-    //         if (dist_diff_edg2 < 3 && abs(angle_diff_deg_edg2 - 0) > 4 && abs(angle_diff_deg_edg2 - 180) > 4 &&
-    //              dist_diff_edg1 < 3 && abs(angle_diff_deg_edg1 - 0) > 4 && abs(angle_diff_deg_edg1 - 180) > 4){
-    //             if (idx_correct == 0) {
-    //                 edgels_HYPO2_corrected = Eigen::MatrixXd(1, 10);
-    //             } else {
-    //                 edgels_HYPO2_corrected.conservativeResize(idx_correct+1, 10);
-    //             }
-                
-    //             if (idx_correct >= max_possible_size) {
-    //                 std::cout << "ERROR: Buffer size exceeded! Increase max_possible_size." << std::endl;
-    //                 break;
-    //             }
-    //             edgels_HYPO2_corrected.conservativeResize(idx_correct+1,10);
-    //             edgels_HYPO2_corrected.row(idx_correct) << x_intersection_1, y_intersection_1, edgel_HYPO1(0,2), edgel_HYPO1(0,3), \
-    //                                                 x_intersection, y_intersection, edgels_HYPO2(idx_hypo2,2), edgels_HYPO2(idx_hypo2,3), \
-    //                                                 HYPO2_idx_raw(idx_hypo2), idx_hypo2;
-    //             idx_correct++;
-    //         }
-    //     }
-
-    //     return edgels_HYPO2_corrected;
+    // ////////////// find cofficients for tangent and epipolar line for edge 1 //////////////
+    // double a_edgeH1 = tan(edgel_HYPO1(0,2)); //tan(theta2)
+    // double b_edgeH1 = -1;
+    // double c_edgeH1 = -(a_edgeH1*edgel_HYPO1(0,0)-edgel_HYPO1(0,1)); //−(a⋅x2−y2)
+    // double x_intersection_1 = ( (b2_line * c_edgeH1 - b_edgeH1 * c2_line) / (a2_line * b_edgeH1 - a_edgeH1 * b2_line) + edgel_HYPO1(0,0) ) / 2;
+    // double y_intersection_1 = ( (c2_line * a_edgeH1 - c_edgeH1 * a2_line) / (a2_line * b_edgeH1 - a_edgeH1 * b2_line) + edgel_HYPO1(0,1) ) / 2;
+    // double dist_diff_edg1    = sqrt((x_intersection_1 - edgel_HYPO1(0,0))*(x_intersection_1 - edgel_HYPO1(0,0))+(y_intersection_1 - edgel_HYPO1(0,1))*(y_intersection_1 - edgel_HYPO1(0,1)));
+    // if (x_intersection_1 == 0 && y_intersection_1 == 0) {
+    //     std::cout << "WARNING: Found (0,0) intersection!" << std::endl;
     // }
-
+    ////////////// find cofficients for tangent and epipolar line for edge 1 //////////////
+    // double x_intersection = ( (b1_line * c_edgeH2 - b_edgeH2 * c1_line) / (a1_line * b_edgeH2 - a_edgeH2 * b1_line) + edgels_HYPO2(idx_hypo2,0) ) / 2;
+    // double y_intersection = ( (c1_line * a_edgeH2 - c_edgeH2 * a1_line) / (a1_line * b_edgeH2 - a_edgeH2 * b1_line) + edgels_HYPO2(idx_hypo2,1) ) / 2;
+    // // check if H1 edge's tangent line is almost parallal to epipolar line
+    // double angle_edgeH1 = edgel_HYPO1(0,2);  // Slope of tangent line at hyp2
+    // double m_epipolar_edg1 = -a2_line / b2_line;            // Slope of epipolar line
+    // double angle_diff_rad_edg1 = abs(angle_edgeH1 - atan(m_epipolar_edg1));
+    // double angle_diff_deg_edg1 = angle_diff_rad_edg1 * (180.0 / M_PI);
+    // if (angle_diff_deg_edg1 > 180){
+    //     angle_diff_deg_edg1 -= 180;
+    // }
+   
     Eigen::MatrixXd pair_edge_hypothesis::edgelsHYPO2correct_post_validation(
         Eigen::MatrixXd edgels_HYPO2,  Eigen::MatrixXd edgel_HYPO1, 
         Eigen::Matrix3d F21, Eigen::Matrix3d F12, Eigen::MatrixXd HYPO2_idx_raw)
@@ -350,18 +266,7 @@ namespace PairEdgeHypothesis {
         ////////////// find cofficients for tangent and epipolar line for edge 2 //////////////
         
         for(int idx_hypo2 = 0; idx_hypo2 < edgels_HYPO2.rows(); idx_hypo2++){
-            // Parameters of the line passing through hypo2 along its angle
-            double a_edgeH2 = tan(edgels_HYPO2(idx_hypo2,2)); //tan(theta2)
-            double b_edgeH2 = -1;
-            double c_edgeH2 = -(a_edgeH2*edgels_HYPO2(idx_hypo2,0)-edgels_HYPO2(idx_hypo2,1)); //−(a⋅x2−y2)
-            // double x_intersection = ( (b1_line * c_edgeH2 - b_edgeH2 * c1_line) / (a1_line * b_edgeH2 - a_edgeH2 * b1_line) + edgels_HYPO2(idx_hypo2,0) ) / 2;
-            // double y_intersection = ( (c1_line * a_edgeH2 - c_edgeH2 * a1_line) / (a1_line * b_edgeH2 - a_edgeH2 * b1_line) + edgels_HYPO2(idx_hypo2,1) ) / 2;
-            double x_intersection = (b1_line * c_edgeH2 - b_edgeH2 * c1_line) / (a1_line * b_edgeH2 - a_edgeH2 * b1_line);
-            double y_intersection = (c1_line * a_edgeH2 - c_edgeH2 * a1_line) / (a1_line * b_edgeH2 - a_edgeH2 * b1_line);
-            double dist_diff_edg2    = sqrt((x_intersection - edgels_HYPO2(idx_hypo2,0))*(x_intersection - edgels_HYPO2(idx_hypo2,0))+(y_intersection -  edgels_HYPO2(idx_hypo2,1))*(y_intersection - edgels_HYPO2(idx_hypo2,1)));
-            
 
-            ////////////// find cofficients for tangent and epipolar line for edge 1 //////////////
             Eigen::MatrixXd xy1_H2;
             xy1_H2.conservativeResize(1,3);
             xy1_H2(0,0) = edgels_HYPO2(idx_hypo2,0);
@@ -375,70 +280,92 @@ namespace PairEdgeHypothesis {
             double a2_line  = -Apixel_2(0,0)/Bpixel_2(0,0);
             double b2_line  = -1;
             double c2_line  = -Cpixel_2(0,0)/Bpixel_2(0,0);
-            double a_edgeH1 = tan(edgel_HYPO1(0,2)); //tan(theta2)
-            double b_edgeH1 = -1;
-            double c_edgeH1 = -(a_edgeH1*edgel_HYPO1(0,0)-edgel_HYPO1(0,1)); //−(a⋅x2−y2)
-            double x_intersection_1 = ( (b2_line * c_edgeH1 - b_edgeH1 * c2_line) / (a2_line * b_edgeH1 - a_edgeH1 * b2_line) + edgel_HYPO1(0,0) ) / 2;
-            double y_intersection_1 = ( (c2_line * a_edgeH1 - c_edgeH1 * a2_line) / (a2_line * b_edgeH1 - a_edgeH1 * b2_line) + edgel_HYPO1(0,1) ) / 2;
-            double dist_diff_edg1    = sqrt((x_intersection_1 - edgel_HYPO1(0,0))*(x_intersection_1 - edgel_HYPO1(0,0))+(y_intersection_1 - edgel_HYPO1(0,1))*(y_intersection_1 - edgel_HYPO1(0,1)));
-            ////////////// find cofficients for tangent and epipolar line for edge 1 //////////////
+            double corrected_x, corrected_y;
+
+            ////////////// calculate normal distance between edge and epipolar line //////////////
+            double epiline_x = xy1_H2(0,0) - a1_line * (a1_line * xy1_H2(0,0) + b1_line *xy1_H2(0,1) + c1_line)/(pow(a1_line,2) + pow(b1_line,2));
+            double epiline_y = xy1_H2(0,1) - b1_line* (a1_line * xy1_H2(0,0) + b1_line * xy1_H2(0,1) + c1_line)/(pow(a1_line,2) + pow(b1_line,2));
+            double distance_epiline = sqrt(pow(xy1_H2(0,0) - epiline_x, 2) + pow(xy1_H2(0,1) - epiline_y, 2));
+            ////////////// calculate normal distance between edge and epipolar line //////////////
+
+            double tangential_distance;
+            if (distance_epiline < 0.3){
+                // If normal distance is small, move directly to epipolar line
+                corrected_x = epiline_x;
+                corrected_y = epiline_y;
+            }else {
+                //////////////// rotate the edge ////////////////
+                double theta = edgels_HYPO2(idx_hypo2,2);
+                double p_theta = a1_line * cos(theta) + b1_line * sin(theta);
+                double derivative_p_theta = -a1_line * sin(theta) + b1_line * cos(theta);
+                double theta_bar = 0.174533; //10 degrees
             
-            if (x_intersection == 0 && y_intersection == 0) {
-                std::cout << "WARNING: Found (0,0) intersection! idx_hypo2: " << idx_hypo2 << std::endl;
-            }
-            if (x_intersection_1 == 0 && y_intersection_1 == 0) {
-                std::cout << "WARNING: Found (0,0) intersection!" << std::endl;
-            }
-
-            // check if H2 edge's tangent line is almost parallal to epipolar line
-            double angle_edgeH2 = edgels_HYPO2(idx_hypo2,2);  // Slope of tangent line at hyp2
-            double m_epipolar_edg2 = -a1_line / b1_line;            // Slope of epipolar line
-            double angle_diff_rad_edg2 = abs(angle_edgeH2 - atan(m_epipolar_edg2));
-            double angle_diff_deg_edg2 = angle_diff_rad_edg2 * (180.0 / M_PI);
-            if (angle_diff_deg_edg2 > 180){
-                angle_diff_deg_edg2 -= 180;
-            }
-
-            // check if H2 edge's tangent line is almost parallal to epipolar line
-            double angle_edgeH1 = edgel_HYPO1(0,2);  // Slope of tangent line at hyp2
-            double m_epipolar_edg1 = -a2_line / b2_line;            // Slope of epipolar line
-            double angle_diff_rad_edg1 = abs(angle_edgeH1 - atan(m_epipolar_edg1));
-            double angle_diff_deg_edg1 = angle_diff_rad_edg1 * (180.0 / M_PI);
-            if (angle_diff_deg_edg1 > 180){
-                angle_diff_deg_edg1 -= 180;
-            }
-
-            // if (dist_diff_edg2 < 6 && abs(angle_diff_deg_edg2 - 0) > 4 && abs(angle_diff_deg_edg2 - 180) > 4 &&
-            //     dist_diff_edg1 < 6 && abs(angle_diff_deg_edg1 - 0) > 4 && abs(angle_diff_deg_edg1 - 180) > 4){
-            if (dist_diff_edg2 < 3 && abs(angle_diff_deg_edg2 - 0) > 4 && abs(angle_diff_deg_edg2 - 180) > 4){
-                if (idx_correct == 0) {
-                    edgels_HYPO2_corrected = Eigen::MatrixXd(1, 10);
-                } else {
-                    edgels_HYPO2_corrected.conservativeResize(idx_correct+1, 10);
+                if (p_theta * derivative_p_theta > 0){
+                    theta = theta - theta_bar;
+                }else{
+                    theta = theta + theta_bar;
                 }
+                //////////////// rotate the edge ////////////////
+
+                ////////////// calculate the intersection between the tangent and epipolar line //////////////
+                double a_edgeH2 = tan(theta); //tan(theta2)
+                double b_edgeH2 = -1;
+                double c_edgeH2 = -(a_edgeH2*edgels_HYPO2(idx_hypo2,0)-edgels_HYPO2(idx_hypo2,1)); //−(a⋅x2−y2)
+
+                double x_intersection = (b1_line * c_edgeH2 - b_edgeH2 * c1_line) / (a1_line * b_edgeH2 - a_edgeH2 * b1_line);
+                double y_intersection = (c1_line * a_edgeH2 - c_edgeH2 * a1_line) / (a1_line * b_edgeH2 - a_edgeH2 * b1_line);
+                double dist_diff_edg2    = sqrt((x_intersection - edgels_HYPO2(idx_hypo2,0))*(x_intersection - edgels_HYPO2(idx_hypo2,0))+(y_intersection -  edgels_HYPO2(idx_hypo2,1))*(y_intersection - edgels_HYPO2(idx_hypo2,1)));
+                if (x_intersection == 0 && y_intersection == 0) {
+                    std::cout << "WARNING: Found (0,0) intersection! idx_hypo2: " << idx_hypo2 << std::endl;
+                }
+                // check if H2 edge's tangent line is almost parallal to epipolar line
+                double m_epipolar_edg2 = -a1_line / b1_line;            // Slope of epipolar line
+                double angle_diff_rad_edg2 = abs(theta - atan(m_epipolar_edg2));
+                double angle_diff_deg_edg2 = angle_diff_rad_edg2 * (180.0 / M_PI);
+                if (angle_diff_deg_edg2 > 180){
+                    angle_diff_deg_edg2 -= 180;
+                }
+                double angle_diff_original = abs(edgels_HYPO2(idx_hypo2,2) - atan(m_epipolar_edg2))  * (180.0 / M_PI);
+                if (angle_diff_original > 180){
+                    angle_diff_original -= 180;
+                }
+                ////////////// calculate the intersection between the tangent and epipolar line //////////////
+                tangential_distance = std::sqrt(std::pow(x_intersection - xy1_H2(0,0), 2) + std::pow(y_intersection - xy1_H2(0,1), 2));
                 
-                if (idx_correct >= max_possible_size) {
-                    std::cout << "ERROR: Buffer size exceeded! Increase max_possible_size." << std::endl;
-                    break;
+                // if (abs(edgel_HYPO1(0,0)-531.497)<0.001  && abs(edgel_HYPO1(0,1)- 398.41)<0.001 && abs(xy1_H2(0,0)-420.637968191121)<0.001 && abs(xy1_H2(0,1)-377.670257834525)<0.001){
+                //     std::cout<<"distance_epiline for target edge is: "<<distance_epiline<<std::endl;
+                //     std::cout<<"tengential distance to epipolar line is: "<<tangential_distance<<std::endl;
+                //     std::cout<<"angle difference before is: "<<angle_diff_original<<std::endl;
+                //     std::cout<<"angle difference after is: "<<angle_diff_deg_edg2<<std::endl;
+                //     exit(0);
+                // }
+
+                if (dist_diff_edg2 < EPIP_TANGENCY_ORIENT_THRESH){// && abs(angle_diff_deg_edg2 - 0) > 4 && abs(angle_diff_deg_edg2 - 180) > 4){
+                    corrected_x = x_intersection;
+                    corrected_y = y_intersection;
+                }else{
+                    continue;
                 }
-                edgels_HYPO2_corrected.conservativeResize(idx_correct+1,10);
-                edgels_HYPO2_corrected.row(idx_correct) << edgel_HYPO1(0,0), edgel_HYPO1(0,1), edgel_HYPO1(0,2), edgel_HYPO1(0,3), \
-                                                        x_intersection, y_intersection, edgels_HYPO2(idx_hypo2,2), edgels_HYPO2(idx_hypo2,3), \
-                                                        HYPO2_idx_raw(idx_hypo2), idx_hypo2;
-                // edgels_HYPO2_corrected.row(idx_correct) << x_intersection_1, y_intersection_1, edgel_HYPO1(0,2), edgel_HYPO1(0,3), \
-                //                                     x_intersection, y_intersection, edgels_HYPO2(idx_hypo2,2), edgels_HYPO2(idx_hypo2,3), \
-                //                                     HYPO2_idx_raw(idx_hypo2), idx_hypo2;
-                idx_correct++;
+
+
             }
 
-            // if (abs(edgel_HYPO1(0,0)-342.542)<0.001  && abs(edgel_HYPO1(0,1)-511.939)<0.001 && abs(x_intersection-311.272)<0.001 && abs(y_intersection-491.301)<0.001){
-            //     std::cout<< "epipolar line is: "<< a1_line<<" " << b1_line <<" " <<c1_line <<std::endl;
-            //     std::cout<< "tangent line is: "<< a_edgeH2<<" " << b_edgeH2 <<" " <<c_edgeH2 <<" " <<std::endl;
-            //     std::cout<< "original point location is: " <<edgels_HYPO2(idx_hypo2,0)<< ", "<< edgels_HYPO2(idx_hypo2,1) <<std::endl;
-            //     std::cout<< "angle diff: " << angle_diff_deg << " degrees" <<std::endl;
-            //     std::cout<< "dist diff: " << dist_diff << " pixels" <<std::endl;
-            //     std::cout<< "angle_edgeH2: "<<angle_edgeH2*(180.0 / M_PI)<<std::endl;
-            //     std::cout<< "atan(m_epipolar): "<<atan(m_epipolar)*(180.0 / M_PI)<<std::endl;
+            edgels_HYPO2_corrected.conservativeResize(idx_correct+1,10);
+            edgels_HYPO2_corrected.row(idx_correct) << edgel_HYPO1(0,0), edgel_HYPO1(0,1), edgel_HYPO1(0,2), edgel_HYPO1(0,3), \
+                                                    corrected_x, corrected_y, edgels_HYPO2(idx_hypo2,2), edgels_HYPO2(idx_hypo2,3), \
+                                                    HYPO2_idx_raw(idx_hypo2), idx_hypo2;
+            idx_correct++;
+
+            // if (abs(edgel_HYPO1(0,0)-531.497)<0.001  && abs(edgel_HYPO1(0,1)-398.41)<0.001 && abs(xy1_H2(0,0)-420.637968191121)<0.001 && abs(xy1_H2(0,1)-377.670257834525)<0.001){
+            //     std::cout<<"distance_epiline for target edge is: "<<distance_epiline<<std::endl;
+            //     std::cout<<"tengential distance to epipolar line is: "<<tangential_distance<<std::endl;
+            //     // std::cout<< "epipolar line is: "<< a1_line<<" " << b1_line <<" " <<c1_line <<std::endl;
+            //     // std::cout<< "tangent line is: "<< a_edgeH2<<" " << b_edgeH2 <<" " <<c_edgeH2 <<" " <<std::endl;
+            //     // std::cout<< "corrected location is: " <<x_intersection<< ", "<< y_intersection <<std::endl;
+            //     // std::cout<< "angle diff: " << angle_diff_deg_edg2 << " degrees" <<std::endl;
+            //     // std::cout<< "dist diff: " << dist_diff_edg2 << " pixels" <<std::endl;
+            //     // std::cout<< "angle_edgeH2: "<<angle_edgeH2*(180.0 / M_PI)<<std::endl;
+            //     // std::cout<< "atan(m_epipolar): "<<atan(m_epipolar_edg1)*(180.0 / M_PI)<<std::endl;
             // }
         }
 

--- a/Edge_Reconst/PairEdgeHypo.hpp
+++ b/Edge_Reconst/PairEdgeHypo.hpp
@@ -12,7 +12,7 @@
 #include <string.h>
 #include <assert.h>
 #include <vector>
-#include <chrono>
+#include <memory>
 
 //> Eigen library
 #include <Eigen/Core>
@@ -20,7 +20,8 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "definitions.h"
+
+#include "util.hpp"
 
 namespace PairEdgeHypothesis {
     
@@ -42,8 +43,10 @@ namespace PairEdgeHypothesis {
         Eigen::MatrixXd edgelsHYPO2correct_post_validation(Eigen::MatrixXd edgels_HYPO2,  Eigen::MatrixXd edgel_HYPO1, Eigen::Matrix3d F21, Eigen::Matrix3d F12, Eigen::MatrixXd HYPO2_idx_raw);
 
     private:
+        std::shared_ptr<MultiviewGeometryUtil::multiview_geometry_util> util = nullptr;
         double reproj_dist_thresh;
         int circle_R;
+        
 
     };
 

--- a/Edge_Reconst/PairEdgeHypo.hpp
+++ b/Edge_Reconst/PairEdgeHypo.hpp
@@ -20,6 +20,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include "definitions.h"
 
 namespace PairEdgeHypothesis {
     

--- a/Edge_Reconst/definitions.h
+++ b/Edge_Reconst/definitions.h
@@ -10,6 +10,10 @@
 //> Print out in terminal
 #define SHOW_EDGE_SKETCH_SETTINGS     (false)
 
+//> Form hypothesis edges parameters
+#define EPIP_TANGENCY_ORIENT_THRESH     (4)     //> in degrees
+#define EPIP_TANGENCY_DISPL_THRESH      (3)     //> in pixels
+
 //> Edge graph pruning parameters
 #define PRUNE_3D_EDGE_GRAPH_LAMBDA1     (0.5)
 #define PRUNE_3D_EDGE_GRAPH_LAMBDA2     (0.5)

--- a/Edge_Reconst/edge_mapping.hpp
+++ b/Edge_Reconst/edge_mapping.hpp
@@ -10,6 +10,8 @@
 #include <memory>
 
 #include "util.hpp"
+#include "file_reader.hpp"
+#include "definitions.h"
 
 // Hash function for Eigen::Vector3d to use in unordered_map
 struct HashEigenVector3d {
@@ -99,6 +101,7 @@ public:
         Eigen::Vector3d location;  
         Eigen::Vector3d orientation; 
         std::vector<std::pair<int, EdgeNode*>> neighbors;
+        bool has_orientation_fixed_in_connectivity_graph;
     };
 
     struct ConnectivityGraphNode {
@@ -160,12 +163,14 @@ public:
     using EdgeNodeList = std::vector<std::unique_ptr<EdgeNode>>;
 
 
-    std::vector<std::vector<SupportingEdgeData>> findMergable2DEdgeGroups(const std::vector<Eigen::Matrix3d> all_R,const std::vector<Eigen::Vector3d> all_T, const Eigen::Matrix3d K, const int Num_Of_Total_Imgs,  const std::vector<Eigen::MatrixXd> All_Edgels);
+    std::vector<std::vector<SupportingEdgeData>> findMergable2DEdgeGroups(const std::vector<Eigen::Matrix3d> all_R,const std::vector<Eigen::Vector3d> all_T, const Eigen::Matrix3d K, const int Num_Of_Total_Imgs);
     
     std::unordered_map<Eigen::Vector3d, std::vector<SupportingEdgeData>, HashEigenVector3d> edge_3D_to_supporting_edges;
     std::unordered_map<Uncorrected2DEdgeKey, std::vector<Uncorrected2DEdgeMappingData>, HashUncorrected2DEdgeKey> map_Uncorrected2DEdge_To_SupportingData();
     std::unordered_map<std::pair<Eigen::Vector3d, Eigen::Vector3d>, int, HashEigenVector3dPair, FuzzyVector3dPairEqual>
-    build3DEdgeWeightedGraph(const std::unordered_map<Uncorrected2DEdgeKey, std::vector<Uncorrected2DEdgeMappingData>, HashUncorrected2DEdgeKey>& uncorrected_map, const std::vector<Eigen::MatrixXd> All_Edgels);
+    build3DEdgeWeightedGraph(const std::unordered_map<Uncorrected2DEdgeKey, std::vector<Uncorrected2DEdgeMappingData>, HashUncorrected2DEdgeKey>& uncorrected_map, 
+                            const std::vector<Eigen::MatrixXd> All_Edgels, std::vector<EdgeCurvelet> all_curvelets,
+                            const std::vector<Eigen::Matrix3d> All_R, const std::vector<Eigen::Vector3d> All_T);
     //EdgeNodeList createEdgeNodesFromEdges(const std::vector<Eigen::Vector3d>& locations, const std::unordered_map<std::pair<Eigen::Vector3d, Eigen::Vector3d>, int, HashEigenVector3dPair, FuzzyVector3dPairEqual>& pruned_graph);
     //EdgeNodeList createEdgeNodesFromFiles(const std::string& points_file, const std::string& tangents_file, const std::string& connections_file);
 
@@ -193,10 +198,11 @@ public:
                                                                                                                                                     const Eigen::Matrix3d K,
                                                                                                                                                     const int Num_Of_Total_Imgs
                                                                                                                                                     );
-
+    std::vector<EdgeCurvelet> read_curvelets(int thresh_EDG = 1);
+    std::vector<Eigen::MatrixXd> read_edgels(int thresh_EDG = 1);
 private:
     std::shared_ptr<MultiviewGeometryUtil::multiview_geometry_util> util = nullptr;
-
+    std::shared_ptr<file_reader> file_reader_ptr = nullptr;
     void write_edge_graph( std::unordered_map<std::pair<Eigen::Vector3d, Eigen::Vector3d>, int, HashEigenVector3dPair, FuzzyVector3dPairEqual>& graph, std::string file_name );
 
 };

--- a/Edge_Reconst/getReprojectedEdgel.cpp
+++ b/Edge_Reconst/getReprojectedEdgel.cpp
@@ -129,6 +129,52 @@ namespace GetReprojectedEdgel {
         return edge_tgt_gamma3;
     }
 
+    Eigen::MatrixXd get_Reprojected_Edgel::getGamma3LocationAndTangent(int hyp01_view_indx, int hyp02_view_indx, Eigen::MatrixXd pt_edge_HYPO1, Eigen::MatrixXd edgels_HYPO2, std::vector<Eigen::Matrix3d> All_R, std::vector<Eigen::Vector3d> All_T, int VALID_INDX, Eigen::Matrix3d K1, Eigen::Matrix3d K2) {
+        MultiviewGeometryUtil::multiview_geometry_util util;
+        Eigen::Vector3d pt_edgel_HYPO1;
+        // pt_edgel_HYPO1 << pt_edge_HYPO1(0,0), pt_edge_HYPO1(0,1), 1;
+        // Eigen::Vector3d Gamma1 = K1.inverse() * pt_edgel_HYPO1;
+        Eigen::Vector3d e1  = {1,0,0};
+        Eigen::Vector3d e3  = {0,0,1};
+        Eigen::Matrix3d R1  = All_R[hyp01_view_indx];
+        Eigen::Vector3d T1  = All_T[hyp01_view_indx];
+        Eigen::Matrix3d R2  = All_R[hyp02_view_indx];
+        Eigen::Vector3d T2  = All_T[hyp02_view_indx];
+        Eigen::Matrix3d R3  = All_R[VALID_INDX];
+        Eigen::Vector3d T3  = All_T[VALID_INDX];
+        Eigen::Matrix3d R21 = util.getRelativePose_R21(R1, R2);
+        Eigen::Vector3d T21 = util.getRelativePose_T21(R1, R2, T1, T2);
+        Eigen::Matrix3d R31 = util.getRelativePose_R21(R1, R3);
+        Eigen::Vector3d T31 = util.getRelativePose_T21(R1, R3, T1, T3);
+        Eigen::MatrixXd edge_loc_tgt_gamma3;
+        edge_loc_tgt_gamma3.conservativeResize(edgels_HYPO2.rows(),4);
+        for (int idx_HYPO2 = 0; idx_HYPO2 < edgels_HYPO2.rows(); idx_HYPO2++){
+            pt_edgel_HYPO1 << pt_edge_HYPO1(idx_HYPO2,0), pt_edge_HYPO1(idx_HYPO2,1), 1;
+            Eigen::Vector3d Gamma1 = K1.inverse() * pt_edgel_HYPO1;
+            Eigen::Vector3d tgt1_meters = getTGT_Meters(pt_edge_HYPO1, K1);
+            Eigen::MatrixXd pt_edge_HYPO2 = edgels_HYPO2.row(idx_HYPO2);
+            Eigen::Vector3d pt_edgel_HYPO2;
+            pt_edgel_HYPO2 << pt_edge_HYPO2(0,0), pt_edge_HYPO2(0,1), 1;
+            Eigen::Vector3d Gamma2 = K2.inverse() * pt_edgel_HYPO2;
+            double rho1 = (double(e1.transpose() * T21) - double(e3.transpose() * T21) * double(e1.transpose() *Gamma2))/(double(e3.transpose() * R21 * Gamma1)* double(e1.transpose() * Gamma2) - double(e1.transpose() * R21 * Gamma1));
+            double rho3 = rho1 * double(e3.transpose() * R31 * Gamma1) + double(e3.transpose()*T31);
+            Eigen::Vector3d Gamma3 = 1 / rho3 * (R31 * rho1 * Gamma1 + T31);
+            Eigen::Vector3d Gamma3_pixel = K2 * Gamma3;
+            Eigen::Vector3d tgt2_meters = getTGT_Meters(pt_edge_HYPO2, K2);
+            Eigen::Vector3d n1 = tgt1_meters.cross(Gamma1);
+            Eigen::Vector3d n2 = R21.transpose() * tgt2_meters.cross(Gamma2);
+            Eigen::Vector3d T_v1 = n1.cross(n2) / (n1.cross(n2) ).norm();
+            Eigen::Vector3d T_v3 = R31 * T_v1;
+            Eigen::Vector3d Tt_v3 = T_v3 - double(e3.transpose()*T_v3)*Gamma3;
+            Eigen::Vector3d t_v3  = Tt_v3 / Tt_v3.norm();
+            // if(IF_ICLNUIM_DATASET == 1){
+            //     t_v3(1) = -1*t_v3(1);
+            // }
+            edge_loc_tgt_gamma3.row(idx_HYPO2) << Gamma3_pixel(0), Gamma3_pixel(1), t_v3(0), t_v3(1);
+        }
+        return edge_loc_tgt_gamma3;
+    }
+
 }
 
 #endif

--- a/Edge_Reconst/getReprojectedEdgel.hpp
+++ b/Edge_Reconst/getReprojectedEdgel.hpp
@@ -30,7 +30,7 @@ namespace GetReprojectedEdgel {
         Eigen::Vector3d getTGT_Meters(Eigen::MatrixXd pt_edge, Eigen::Matrix3d K);
         Eigen::MatrixXd getGamma3Pos(int hyp01_view_indx, int hyp02_view_indx, Eigen::MatrixXd pt_edge_HYPO1, Eigen::MatrixXd edgels_HYPO2, std::vector<Eigen::Matrix3d> All_R, std::vector<Eigen::Vector3d> All_T, int VALID_INDX, Eigen::Matrix3d K1, Eigen::Matrix3d K2, Eigen::Matrix3d K3);
         Eigen::MatrixXd getGamma3Tgt(int hyp01_view_indx, int hyp02_view_indx, Eigen::MatrixXd pt_edge_HYPO1, Eigen::MatrixXd edgels_HYPO2, std::vector<Eigen::Matrix3d> All_R, std::vector<Eigen::Vector3d> All_T, int VALID_INDX, Eigen::Matrix3d K1, Eigen::Matrix3d K2);
-
+        Eigen::MatrixXd getGamma3LocationAndTangent(int hyp01_view_indx, int hyp02_view_indx, Eigen::MatrixXd pt_edge_HYPO1, Eigen::MatrixXd edgels_HYPO2, std::vector<Eigen::Matrix3d> All_R, std::vector<Eigen::Vector3d> All_T, int VALID_INDX, Eigen::Matrix3d K1, Eigen::Matrix3d K2);
 
     private:
         

--- a/Edge_Reconst/util.hpp
+++ b/Edge_Reconst/util.hpp
@@ -78,6 +78,15 @@ namespace MultiviewGeometryUtil {
 
         std::vector<double> check_reproj_error(std::vector<Eigen::Vector2d> points_2D, Eigen::Vector3d point_3D, 
                                                std::vector<Eigen::Matrix3d> Rs, std::vector<Eigen::Vector3d> Ts, Eigen::Matrix3d K);
+
+        double rad_to_deg( double theta ) {
+            return theta * (180.0 / M_PI);
+        }
+
+        double deg_to_rad( double theta ) {
+            return theta * (M_PI / 180.0);
+        }
+
     private:
         
     };

--- a/cmd/main.cpp
+++ b/cmd/main.cpp
@@ -143,7 +143,7 @@ int main(int argc, char **argv) {
   // edgeMapping->printFirst10Edges();
   std::cout << "====================================================================" << std::endl;
 
-  std::vector<std::vector<EdgeMapping::SupportingEdgeData>> all_groups = edgeMapping->findMergable2DEdgeGroups(MWV_Edge_Rec.All_R, MWV_Edge_Rec.All_T, MWV_Edge_Rec.K, MWV_Edge_Rec.Num_Of_Total_Imgs, MWV_Edge_Rec.All_Edgels);
+  std::vector<std::vector<EdgeMapping::SupportingEdgeData>> all_groups = edgeMapping->findMergable2DEdgeGroups(MWV_Edge_Rec.All_R, MWV_Edge_Rec.All_T, MWV_Edge_Rec.K, MWV_Edge_Rec.Num_Of_Total_Imgs);
   // std::string outputFilePath = "../../outputs/grouped_mvt.txt";
   // std::string outputFilePath_tangent = "../../outputs/grouped_mvt_tangent.txt";
   // NViewsTrian::grouped_mvt(all_groups, outputFilePath, outputFilePath_tangent);

--- a/test/test_functions.cpp
+++ b/test/test_functions.cpp
@@ -45,6 +45,27 @@ void read_curvelets() {
 
 }
 
+std::pair<int, int> findConnectedEdges_test(std::vector<double> proj_neighbor) {
+    int left_idx = -1;
+    double min_positive = std::numeric_limits<double>::max();
+    
+    int right_idx = -1;
+    double max_negative = -std::numeric_limits<double>::max();
+    
+    for (size_t j = 0; j < proj_neighbor.size(); ++j) {
+        if (proj_neighbor[j] >= 0 && proj_neighbor[j] < min_positive) {
+            min_positive = proj_neighbor[j];
+            left_idx = j;
+        }
+        if (proj_neighbor[j] < 0 && proj_neighbor[j] > max_negative) {
+            max_negative = proj_neighbor[j];
+            right_idx = j;
+        }
+    }
+
+    return {left_idx, right_idx};
+}
+
 std::pair<int, int> findConnectedEdges(std::vector<double> proj_neighbor) {
     if (proj_neighbor.size() < 2) {
         return {-1, -1}; 
@@ -121,7 +142,8 @@ std::vector<std::pair<int, Eigen::Vector3d>> getConnectivityGraph(EdgeNode* node
 
         // std::cout << neighbor->location.transpose() << "\tline_latent_variable = " << line_latent_variable << std::endl;
     }
-    std::pair<int, int> connected_edge_index = findConnectedEdges( proj_neighbor );
+    // std::pair<int, int> connected_edge_index = findConnectedEdges( proj_neighbor );
+    std::pair<int, int> connected_edge_index = findConnectedEdges_test( proj_neighbor );
 
     //>**************************************************************************************************
     //> Write updated_neighbors to the file for testing

--- a/visualization/plot_curves.m
+++ b/visualization/plot_curves.m
@@ -63,15 +63,19 @@ figure;
 hold on;
 
 % Define a fixed set of 20 distinct colors that will repeat
-fixed_colors = jet(20);
+fixed_colors = jet(30);
 
 % Plot each curve
 for i = 1:num_curves
     curve_idx = curve_ids == unique_curves(i);
     points = curve_data(curve_idx, 1:3);
+
+    if size(points, 1) < 10
+        continue;
+    end
     
     % Use modulo to cycle through the 20 colors
-    color_idx = mod(i-1, 20) + 1;
+    color_idx = mod(i-1, 30) + 1;
     color = fixed_colors(color_idx, :);
     
     plot3(points(:, 1), points(:, 2), points(:, 3), '-', 'LineWidth', 2, 'Color', color);


### PR DESCRIPTION
Some major updates have been made:
- 2D edge links from curvelets have been used to uplift the connections between 3D edges in the 3D edge neighborhood graph.
- Epipolar shift now takes edge localization and orientation certainty into account to avoid rejecting edges that are good candidate in pairing up hypothesis edges.
- Some small curve fragments arise from incorrect construction of 3D edge connectivity graph has been fixed.