### PR TITLE
Initiate precision-recall experiments

### DIFF
--- a/3D_Edge_Sketch_Settings.yaml
+++ b/3D_Edge_Sketch_Settings.yaml
@@ -2,8 +2,8 @@
 
 #> 3D Edge Sketch Settings
 Num_Of_OMP_Threads: 32                #> Number of CPU cores to run 3D Edge Sketch in parallel
-Init_Hypo1_View_Index: 28 #44            #> Initial hypothesis view 1 index
-Init_Hypo2_View_Index: 48 #29            #> Initial hypothesis view 2 index
+Init_Hypo1_View_Index: 25 #44            #> Initial hypothesis view 1 index
+Init_Hypo2_View_Index: 49 #29            #> Initial hypothesis view 2 index
 delta: 0.3                            #> edge location perturbation
 delta_theta: 15                       #> \Delta \theta: orientation threshold
 Max_Num_Of_Support_Views: 4           #> N: minimal number of validation views supporting a hypothesis edge pair
@@ -12,7 +12,7 @@ Multi_Thresh_Final_Thresh: 1          #> third-order edge threshold for last rou
 Parallel_Epipolar_Line_Angle: 15      #> decide if the picked hypothesis view should be abandoned by the angle between two epipolar lines
 Reproj_Dist_Thresh: 2                 #> distance threshold between observed edge and reprojected edge on the validation view (probably not in use)
 Ratio_Of_Claimed_Edges_to_Stop: 0.97   #> stopping 3D Edge Sketch by what ratio of the projected edges claimed by the observed edges
-Max_Num_Of_3D_Edge_Sketch_Passes: 5
+Max_Num_Of_3D_Edge_Sketch_Passes: 1
 
 #> Dataset Settings
 Dataset_Path: /gpfs/data/bkimia/Datasets/

--- a/Edge_Reconst/EdgeClusterer.cpp
+++ b/Edge_Reconst/EdgeClusterer.cpp
@@ -222,6 +222,8 @@ Eigen::MatrixXd EdgeClusterer::performClustering( Eigen::MatrixXd HYPO2_idx_raw,
 
     Eigen::MatrixXd HYPO2_idx(Num_Of_Epipolar_Corrected_H2_Edges, 1);
 
+    Num_Of_Clusters = clusters.size();
+
     //> For each cluster, compute the Gaussian-weighted average edge and update all edges in the cluster
     for (size_t c = 0; c < clusters.size(); ++c) {
         const std::vector<int>& cluster = clusters[c];

--- a/Edge_Reconst/EdgeClusterer.hpp
+++ b/Edge_Reconst/EdgeClusterer.hpp
@@ -35,6 +35,7 @@ public:
     std::vector<int> cluster_labels;
     std::vector<std::vector<int> > clusters;
     std::unordered_map<int, double> cluster_avg_orientations;
+    unsigned Num_Of_Clusters;
     
     //> For each edge index, store all other edge indices in the same cluster
     std::unordered_map<std::pair<int, int>, std::vector<int>, PairHash> H2_Clusters; //<H1 edge index, H2 edge index>, cluster of H2 edges

--- a/Edge_Reconst/EdgeSketch_Core.hpp
+++ b/Edge_Reconst/EdgeSketch_Core.hpp
@@ -48,6 +48,19 @@ public:
     std::vector< std::vector< std::unordered_map<std::pair<int, int>, std::vector<int>, PairHash> > > local_hypo2_clusters;
     std::unordered_map<std::pair<int, int>, std::vector<int>, PairHash> hypo2_clusters;
 
+    //> Precision and recall
+    //> (i) local PR rates in the scope of CPU threads
+    std::vector< std::vector< std::pair<double, double> > > PR_before_clustering;
+    std::vector< std::vector< std::pair<double, double> > > PR_after_clustering;
+    std::vector< std::vector< std::pair<double, double> > > PR_after_validation;
+    //> (ii) global PR rates
+    std::pair<double, double> avg_PR_before_clustering;
+    std::pair<double, double> avg_PR_after_clustering;
+    std::pair<double, double> avg_PR_after_validation;
+    //> (iii) Number of correct/wrong edges
+    int num_of_correct_edges_before_clustering, num_of_wrong_edges_before_clustering;
+    int num_of_correct_edges_after_clustering, num_of_wrong_edges_after_clustering;
+    int num_of_correct_edges_after_validation, num_of_wrong_edges_after_validation;
 
     std::unordered_map<std::pair<int, int>, std::vector<int>, PairHash> hypo2_clusters_CH;
 
@@ -63,6 +76,10 @@ public:
     void Stack_3D_Edges();
     void Project_3D_Edges_and_Find_Next_Hypothesis_Views();
     void Calculate_Edge_Support_Ratios_And_Select_Next_Views(std::shared_ptr<EdgeMapping> edgeMapping);
+
+    //> precision and recall experiments
+    bool getGTEdgePairsBetweenImages(int hyp01_view_indx, int hyp02_view_indx, std::vector<std::pair<int, int>>& gt_edge_pairs);
+    void get_Avg_Precision_Recall_Rates();
 
     std::unordered_map<int, int> saveBestMatchesToFile(const std::unordered_map<int, int>& hypothesis1ToBestMatch,
                            const std::unordered_map<int, int>& hypothesis2ToBestMatch,
@@ -129,6 +146,7 @@ public:
     std::vector<Eigen::Matrix3d> All_K;
     std::vector<Eigen::MatrixXd> All_Edgels; 
     Eigen::Matrix3d K;
+    std::vector<std::vector<int>> GT_EdgePairs;
 
     //> Input Dataset Settings
     std::string Dataset_Path;
@@ -251,8 +269,6 @@ private:
     double Parallel_Epipolar_Line_Angle_Deg;
     double Reproj_Dist_Thresh;
     double Stop_3D_Edge_Sketch_by_Ratio_Of_Claimed_Edges;
-    int circleR; //> Unknown setting
-
 
     //> Edges and camera intrinsix/extrinsic matrices of the two hypothesis views
     Eigen::Matrix3d K_HYPO1;
@@ -276,6 +292,8 @@ private:
     Eigen::MatrixXd OreListBardegree;
     Eigen::Vector3d epipole;
 
+    unsigned Num_Of_Clusters_per_H1_Edge;
+
     // data structure for tracking best matches
     std::unordered_map<int, int> hypothesis1_best_match;
     std::unordered_map<int, int> hypothesis2_best_match;
@@ -284,9 +302,6 @@ private:
     std::vector<int> valid_view_index;
 
     std::ofstream V_edges_outFile;
-    std::ofstream V_edges_in_H1_wedges_outFile;
-    std::ofstream V_edges_in_H2_wedges_outFile;
-    std::ofstream V_edges_intersection;
 
     template<typename T>
     T Uniform_Random_Number_Generator(T range_from, T range_to) {

--- a/Edge_Reconst/definitions.h
+++ b/Edge_Reconst/definitions.h
@@ -8,6 +8,10 @@
 #define WRITE_3D_EDGES                  (true)
 #define WRITE_3D_EDGE_GRAPH             (true)
 
+//> NCC on Edges Settings
+#define EDGE_ORTHOGONAL_SHIFT_MAG       (5)         //> in pixels
+#define PATCH_SIZE                      (7)         //> in pixels
+
 //> Print out in terminal
 #define SHOW_EDGE_SKETCH_SETTINGS       (false)
 
@@ -33,13 +37,16 @@
 #define ENABLE_EXPO_FORCE_AND_TORQUE    (false)
 #define EXPO_INCREASE_FACTOR            (sqrt(2))
 
+//> Precision-Recall evaluation parameters
+#define GT_PROXIMITY_THRESH             (1) //> in pixels
+
 //> Debugging purpose
 #define DEBUG                      (0)
 #define DEBUG_READ_FILES           (false)
 #define DEBUG_PAIRED_EDGES         (true)
 #define SHOW_DATA_LOADING_INFO     (false)
 #define SHOW_OMP_NUM_OF_THREADS    (true)
-#define ISOLATE_DATA               (true)
+#define ISOLATE_DATA               (false)
 
 //> Constant values (no change)
 #define PI                            (3.1415926)
@@ -56,6 +63,7 @@
 //> MVT definitions
 
 //> General Settings
+#define USE_REFINED_CAM_POSES           (true)
 #define FIX_RANDOMNESS                  (true)
 #define RUN_CERES_SOLVER_ON             (false)
 

--- a/Edge_Reconst/file_reader.hpp
+++ b/Edge_Reconst/file_reader.hpp
@@ -3,6 +3,7 @@
 
 #include <iostream>
 #include <fstream>
+#include <sstream> 
 #include <vector>
 #include <string>
 #include <Eigen/Dense>
@@ -25,6 +26,7 @@ public:
     void readRmatrix( std::vector<Eigen::Matrix3d> &All_R );
     void readTmatrix( std::vector<Eigen::Vector3d> &All_T );
     void readK( std::vector<Eigen::Matrix3d> &All_K );
+    void readGT_EdgePairs( std::vector<std::vector<int>> &GT_EdgePairs );
 
 private:
     std::string dataset_name_sequence_path;
@@ -36,6 +38,7 @@ private:
     std::string Rmatrix_File_Path;
     std::string Tmatrix_File_Path;
     std::string Kmatrix_File_Path;
+    std::string GT_File_Path;
 };
 
 #endif // FILE_READER_HPP

--- a/evaluation/gen_GT_curve_points.py
+++ b/evaluation/gen_GT_curve_points.py
@@ -48,7 +48,7 @@ def visualize_gt(all_gt_points, all_gt_directions, name, show_dir=False, save_fi
     if show_fig:
         plt.show()
 
-def get_gt_points(name, base_dir, return_direction=False):
+def get_gt_points(name, base_dir, sampling_rate=0.01, return_direction=False):
     objs_dir = os.path.join(base_dir, "obj")
     obj_names = os.listdir(objs_dir)
     obj_names.sort()
@@ -91,7 +91,7 @@ def get_gt_points(name, base_dir, return_direction=False):
             for index in range(len(each_edge_pts) - 1):
                 next = each_edge_pts[index + 1]
                 current = each_edge_pts[index]
-                num = int(np.linalg.norm(next - current) // 0.01)
+                num = int(np.linalg.norm(next - current) // sampling_rate)
                 linspace = np.linspace(0, 1, num)
                 gt_sampling.append(linspace[:, None] * current + (1 - linspace)[:, None] * next)
                 if return_direction:


### PR DESCRIPTION
An attempt to develop precision-recall experiments using ground-truth edge correspondences. This allows us to understand what operating point we are when using the hyper-parameters, and also a chance to figure out how we could improve the precision while maintaining high recall rate.