### PR TITLE
Apply Lowe's ratio test on multiple validated edge hypothese and also link the OpenCV libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,7 @@ set(PROJ_INSTALL_INCLUDE_DIR ${CMAKE_INSTALL_PREFIX}/include/)
 include_directories(${PROJ_INCLUDE_DIRS})
 
 include_directories( "/gpfs/data/bkimia/zqiwu/3D/yaml-cpp/include" )
+include_directories( "/gpfs/data/bkimia/opencv_4.x/build_install/include/opencv4" )
 
 # adds a test for Endianness and a global variable that should be useful for file format programming -MM
 include(TestBigEndian)

--- a/Edge_Reconst/CMakeLists.txt
+++ b/Edge_Reconst/CMakeLists.txt
@@ -43,6 +43,7 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 add_library( edge_reconstruction ${control_sources} )
 target_link_libraries(edge_reconstruction 
         -L/gpfs/data/bkimia/zqiwu/3D/yaml-cpp/bin/lib64 yaml-cpp
+        -L/gpfs/data/bkimia/opencv_4.x/build_install/lib64 opencv_core opencv_imgproc opencv_imgcodecs opencv_highgui opencv_xfeatures2d
         -L/usr/lib64 pthread
 )
 

--- a/Edge_Reconst/CMakeLists.txt
+++ b/Edge_Reconst/CMakeLists.txt
@@ -43,7 +43,7 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 add_library( edge_reconstruction ${control_sources} )
 target_link_libraries(edge_reconstruction 
         -L/gpfs/data/bkimia/zqiwu/3D/yaml-cpp/bin/lib64 yaml-cpp
-        -L/gpfs/data/bkimia/opencv_4.x/build_install/lib64 opencv_core opencv_imgproc opencv_imgcodecs opencv_highgui opencv_xfeatures2d
+        -L/gpfs/data/bkimia/opencv_4.x/build_install/lib64 opencv_core opencv_imgproc opencv_imgcodecs opencv_highgui opencv_features2d opencv_xfeatures2d
         -L/usr/lib64 pthread
 )
 

--- a/Edge_Reconst/definitions.h
+++ b/Edge_Reconst/definitions.h
@@ -12,6 +12,14 @@
 #define EDGE_ORTHOGONAL_SHIFT_MAG       (5)         //> in pixels
 #define PATCH_SIZE                      (7)         //> in pixels
 
+//> LOWE's ratio test
+#define LOWES_RATIO_THRESHOLD           (0.6)
+
+//> SIFT
+#define ENABLE_SIFT_FILTERING           (false)
+#define SIFT_PATCH_SIZE                 (7)
+#define SIFT_DISTANCE_THRESHOLD         (100)
+
 //> Print out in terminal
 #define SHOW_EDGE_SKETCH_SETTINGS       (false)
 

--- a/Edge_Reconst/definitions.h
+++ b/Edge_Reconst/definitions.h
@@ -23,6 +23,7 @@
 #define CLUSTER_ORIENT_THRESH           (20.0)      //> in degrees
 #define MAX_CLUSTER_SIZE                (10)        //> max number of edges per cluster
 #define CLUSTER_ORIENT_GAUSS_SIGMA      (2.0)
+#define ORTHOGONAL_SHIFT_MAG            (5)         //> in pixels
 
 //> Edge graph pruning parameters
 #define PRUNE_3D_EDGE_GRAPH_LAMBDA1     (1)

--- a/Edge_Reconst/file_reader.cpp
+++ b/Edge_Reconst/file_reader.cpp
@@ -24,6 +24,8 @@ file_reader::file_reader( std::string dataset_path, std::string dataset_name, st
 
   //> Read GT edge correspondences for precision-recall experiments
   GT_File_Path = dataset_name_sequence_path + "/GT_edge_pairs_indices_0006.txt";
+
+  Image_File_Source_Path = dataset_name_sequence_path + "/train_img/";
 }
 
 //> Read all edgel files
@@ -42,6 +44,28 @@ void file_reader::read_All_Edgels( std::vector<Eigen::MatrixXd> &All_Edgels, int
 #if SHOW_DATA_LOADING_INFO
   std::cout << "All edgel files are loaded successfully" << std::endl;
 #endif
+}
+
+//> Read only one image
+bool file_reader::read_an_image( int file_idx, cv::Mat &grayscale_img )
+{
+  std::string img_path = Image_File_Source_Path + std::to_string(file_idx) + "_colors.png";
+  cv::Mat original_img = cv::imread(img_path, cv::IMREAD_COLOR);
+
+  if (original_img.empty()) {
+    std::string err_msg = "Image in path " + img_path + " not found!";
+    LOG_ERROR(err_msg);
+    return false;
+  }
+
+  //> Check if converting to a gray-scale image is necessary
+  if (original_img.channels() == 1) {
+    grayscale_img = original_img;
+  }
+  if (original_img.channels() == 3) {
+    cv::cvtColor(original_img, grayscale_img, cv::COLOR_BGR2GRAY);
+  }  
+  return true;
 }
 
 //> Read edgels of a file specified by the file_idx

--- a/Edge_Reconst/file_reader.hpp
+++ b/Edge_Reconst/file_reader.hpp
@@ -6,6 +6,7 @@
 #include <sstream> 
 #include <vector>
 #include <string>
+#include <opencv2/opencv.hpp>
 #include <Eigen/Dense>
 #include "definitions.h"
 
@@ -27,6 +28,7 @@ public:
     void readTmatrix( std::vector<Eigen::Vector3d> &All_T );
     void readK( std::vector<Eigen::Matrix3d> &All_K );
     void readGT_EdgePairs( std::vector<std::vector<int>> &GT_EdgePairs );
+    bool read_an_image( int file_idx, cv::Mat &grayscale_img );
 
 private:
     std::string dataset_name_sequence_path;
@@ -39,6 +41,7 @@ private:
     std::string Tmatrix_File_Path;
     std::string Kmatrix_File_Path;
     std::string GT_File_Path;
+    std::string Image_File_Source_Path;
 };
 
 #endif // FILE_READER_HPP

--- a/README.md
+++ b/README.md
@@ -22,13 +22,23 @@ and also manually add the YAML library to ``LD_LIBRARY_PATH``:
 ```bash
 $ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/XXX/bin/lib64/
 ```
-where ``XXX`` is the installed prefix path of your YAML-CPP.
+where ``XXX`` is the installed prefix path of your YAML-CPP. In addition, to enable the use of OpenCV library, manually link its library we have installed under ``/gpfs/data/bkimia/opencv_4.x/`` by
+```bash
+$ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/gpfs/data/bkimia/opencv_4.x/build_install/lib64/
+```
 
 ## Outputs
 Some intermidiate data when running the code will be saved to files which are stored in a ``outputs/`` folder. All files will be cleared out when the code starts a new run. This can be deactivated by setting the macro ``DELETE_ALL_FILES_UNDER_OUTPUTS`` defined in the ``Edge_Reconst/definitions.h`` file as _false_.
 
 ## Evaluations
-A evaluation script is customized and created under ``evaluation`` folder. For ABC-NEF dataset, you can download the ground-truth sampled curve points from [Google Drive](https://drive.google.com/drive/folders/1FH8_jykq44YA4FGJ6Par4gBMZg7Ayp1q?usp=sharing). It is encouraged to launch a conda environment before running the evaluation script. Follow the commands below to install:
+
+### Dataset
+[ABC-NEF dataset](https://github.com/yunfan1202/NEF_code) provides a set of nice 3D ground-truth curves which can be sampled into 3D edges for evaluating the reconstructed 3D edges/curves. 
+- We observe that the camera absolute poses of the ABC-NEF dataset are not very accurate (this can be seen by first projecting 3D ground-truth curve points onto images, and then around 1-2 pixels of shift from the projected curve points and the true object ridge are observed.) We thus provide code (can be found under the ``refine_ABC_NEF_camera_poses`` folder) for refining absolute camera poses by bundle adjustment, minimizing the nearest neighbor points between projected points and the detected third-order edges. The refined poses for all objects are collected in this Google Drive.  <br />
+- From the projections of 3D sampled curve points, third-order edge correspondences across different views can be constructed. The occlusion is reasonsed by the orientation difference between the projected 3D edge orientation and the third-order edges, as well as the magnitude of projection rays. Again, we made the GT edge correspondences available in this Google Drive.
+
+### Quantitative Evaluation
+An evaluation script is customized and created under ``evaluation`` folder. For ABC-NEF dataset, you can download the ground-truth sampled curve points from [Google Drive](https://drive.google.com/drive/folders/1FH8_jykq44YA4FGJ6Par4gBMZg7Ayp1q?usp=sharing). It is encouraged to launch a conda environment before running the evaluation script. Follow the commands below to install:
 ```bash
 conda create -n edge_sketch python=3.8
 conda activate edge_sketch

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,6 +3,8 @@ SET(TEST_SOURCES test_functions)
 FOREACH (test_src ${TEST_SOURCES})
     ADD_EXECUTABLE(${test_src} ${test_src}.cpp)
     target_include_directories(${test_src} PRIVATE test_include) 
-    TARGET_LINK_LIBRARIES(${test_src} edge_reconstruction)
+    TARGET_LINK_LIBRARIES(${test_src} edge_reconstruction
+        -L/gpfs/data/bkimia/opencv_4.x/build_install/lib64 opencv_core opencv_imgcodecs opencv_highgui opencv_xfeatures2d
+    )
     ADD_TEST(${test_src} ${test_src})
 ENDFOREACH (test_src)

--- a/test/test_functions.cpp
+++ b/test/test_functions.cpp
@@ -11,13 +11,16 @@
 //> test header files
 #include "test_include/test_alignment.hpp"
 #include "test_include/test_epipolar_correction.hpp"
+#include "test_include/test_edge_NCC.hpp"
 
 #include "../Edge_Reconst/definitions.h"
 #include "../Edge_Reconst/util.hpp"
 #include "../Edge_Reconst/file_reader.hpp"
 
 //> Select the test
-#define TEST_EPIPOLAR_CORRECTION    (true)
+#define TEST_EPIPOLAR_CORRECTION    (false)
+#define TEST_EDGE_NCC               (true)
+#define TEST_EDGE_ORIENTATION_AVG   (false)
 #define TEST_READ_CURVELETS         (false)
 #define TEST_EDGE_ALIGNMENT         (false)
 #define TEST_CONNECTIVITY_GRAPH     (false)  //> TEST_EDGE_ALIGNMENT has to be true to activate this test
@@ -81,6 +84,14 @@ int main(int argc, char **argv) {
 #if TEST_EPIPOLAR_CORRECTION
     test_epipolar_correction_main( util );
     LOG_INFOR_MESG("Epipolar correction test is finished!");
+#endif
+
+#if TEST_EDGE_ORIENTATION_AVG
+    f_TEST_EDGE_ORIENTATION_AVG();
+#endif
+
+#if TEST_EDGE_NCC
+    f_TEST_NCC();
 #endif
 
 #if TEST_READ_CURVELETS

--- a/test/test_include/test_edge_NCC.hpp
+++ b/test/test_include/test_edge_NCC.hpp
@@ -1,0 +1,155 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <iostream>
+#include <iomanip>
+#include <Eigen/Core>
+#include <Eigen/Dense>
+#include <Eigen/SVD>
+#include <memory>
+#include <cmath>
+#include <random>
+#include <chrono>
+#include <opencv2/opencv.hpp>
+
+#include "../Edge_Reconst/file_reader.hpp"
+#include "../Edge_Reconst/definitions.h"
+#include "../Edge_Reconst/util.hpp"
+
+void f_TEST_EDGE_ORIENTATION_AVG() {
+
+    Eigen::MatrixXd edge_set;
+    edge_set.conservativeResize(6, 3);
+    edge_set.row(0) << 611.3950, 7.4897, 1.5623;
+    edge_set.row(1) << 611.4090, 7.9915, 1.5564;
+    edge_set.row(2) << 611.4210, 8.4932, 1.5637;
+    edge_set.row(3) << 611.5030, 4.5006, -1.5276;
+    edge_set.row(4) << 611.4360, 5.4918, -1.4957;
+    edge_set.row(5) << 611.4730, 4.9990, -1.5429;
+
+    //> TODO
+}
+
+double Bilinear_Interpolation(const cv::Mat &meshGrid, cv::Point2d P)
+{
+    cv::Point2d Q12(floor(P.x), floor(P.y));
+    cv::Point2d Q22(ceil(P.x), floor(P.y));
+    cv::Point2d Q11(floor(P.x), ceil(P.y));
+    cv::Point2d Q21(ceil(P.x), ceil(P.y));
+
+    if (Q11.x < 0 || Q11.y < 0 || Q21.x >= meshGrid.cols || Q21.y >= meshGrid.rows ||
+        Q12.x < 0 || Q12.y < 0 || Q22.x >= meshGrid.cols || Q22.y >= meshGrid.rows)
+    {
+        return std::numeric_limits<double>::quiet_NaN();
+    }
+
+    double fQ11 = meshGrid.at<float>(Q11.y, Q11.x);
+    double fQ21 = meshGrid.at<float>(Q21.y, Q21.x);
+    double fQ12 = meshGrid.at<float>(Q12.y, Q12.x);
+    double fQ22 = meshGrid.at<float>(Q22.y, Q22.x);
+
+    double f_x_y1 = ((Q21.x - P.x) / (Q21.x - Q11.x)) * fQ11 + ((P.x - Q11.x) / (Q21.x - Q11.x)) * fQ21;
+    double f_x_y2 = ((Q21.x - P.x) / (Q21.x - Q11.x)) * fQ12 + ((P.x - Q11.x) / (Q21.x - Q11.x)) * fQ22;
+    return ((Q12.y - P.y) / (Q12.y - Q11.y)) * f_x_y1 + ((P.y - Q11.y) / (Q12.y - Q11.y)) * f_x_y2;
+}
+
+template<typename T>
+T Uniform_Random_Number_Generator(T range_from, T range_to) {
+    std::random_device                                          rand_dev;
+    std::mt19937                                                rng(rand_dev());
+    std::uniform_int_distribution<std::mt19937::result_type>    distr(range_from, range_to);
+    return distr(rng);
+}
+
+std::pair<cv::Point2d, cv::Point2d> get_Orthogonal_Shifted_Points( const Eigen::Vector3d edgel )
+{
+    double shifted_x1 = edgel(0) + ORTHOGONAL_SHIFT_MAG * (std::sin(edgel(2)));
+    double shifted_y1 = edgel(1) + ORTHOGONAL_SHIFT_MAG * (-std::cos(edgel(2)));
+    double shifted_x2 = edgel(0) + ORTHOGONAL_SHIFT_MAG * (-std::sin(edgel(2)));
+    double shifted_y2 = edgel(1) + ORTHOGONAL_SHIFT_MAG * (std::cos(edgel(2)));
+
+    cv::Point2d shifted_point_plus(shifted_x1, shifted_y1);
+    cv::Point2d shifted_point_minus(shifted_x2, shifted_y2);
+
+    return {shifted_point_plus, shifted_point_minus};
+}
+
+void get_patch_on_one_edge_side( cv::Point2d shifted_point, double theta, \
+                                 cv::Mat &patch_coord_x, cv::Mat &patch_coord_y, \
+                                 cv::Mat &patch_val, const cv::Mat img ) 
+{
+    int half_patch_size = floor(PATCH_SIZE / 2);
+    for (int i = -half_patch_size; i <= half_patch_size; i++) {
+        for (int j = -half_patch_size; j <= half_patch_size; j++) {
+            //> get the rotated coordinate
+            cv::Point2d rotated_point(cos(theta)*(i) - sin(theta)*(j) + shifted_point.x, sin(theta)*(i) + cos(theta)*(j) + shifted_point.y);
+            patch_coord_x.at<double>(i + half_patch_size, j + half_patch_size) = rotated_point.x;
+            patch_coord_y.at<double>(i + half_patch_size, j + half_patch_size) = rotated_point.y;
+
+            //> get the image intensity of the rotated coordinate
+            double interp_val = Bilinear_Interpolation(img, rotated_point);
+            patch_val.at<double>(i + half_patch_size, j + half_patch_size) = interp_val;
+        }
+    }
+}
+
+void f_TEST_NCC() 
+{
+    std::shared_ptr<MultiviewGeometryUtil::multiview_geometry_util> util = nullptr;
+    util = std::shared_ptr<MultiviewGeometryUtil::multiview_geometry_util>(new MultiviewGeometryUtil::multiview_geometry_util());
+
+    std::string source_dataset_folder = "/gpfs/data/bkimia/Datasets/";
+    std::string dataset_name = "ABC-NEF/";
+    std::string object_name = "00000006";
+    cv::Mat gray_img;
+
+    file_reader data_loader(source_dataset_folder, dataset_name, object_name, 50);
+    Eigen::MatrixXd edges = data_loader.read_Edgels_Of_a_File(0, 1);              //> Edge_0_t1.txt
+    bool b_get_img = data_loader.read_an_image(0, gray_img);
+    if (!b_get_img) exit(1);
+    
+    int rand_edge_idx;
+    while (true) {
+        rand_edge_idx = Uniform_Random_Number_Generator< int >(0, edges.rows()-1);
+        double target_edge_orient = edges(rand_edge_idx, 2); 
+        if (fabs(fabs(target_edge_orient) - fabs(M_PI / 4.0)) < 0.02)
+            break;
+    }
+
+    Eigen::Vector3d target_edge(edges(rand_edge_idx, 0), edges(rand_edge_idx, 1), edges(rand_edge_idx, 2));
+    
+    std::cout << "Picked edge: (" << target_edge(0) << ", " << target_edge(1) << ", " << target_edge(2) << ")" << std::endl;
+    std::cout << "Orientation in degree: " << util->rad_to_deg(target_edge(2)) << std::endl;
+
+    std::pair<cv::Point2d, cv::Point2d> shifted_points = get_Orthogonal_Shifted_Points( target_edge );
+
+    cv::Mat patch_coord_x_plus  = cv::Mat_<double>(PATCH_SIZE, PATCH_SIZE);
+    cv::Mat patch_coord_y_plus  = cv::Mat_<double>(PATCH_SIZE, PATCH_SIZE);
+    cv::Mat patch_coord_x_minus = cv::Mat_<double>(PATCH_SIZE, PATCH_SIZE);
+    cv::Mat patch_coord_y_minus = cv::Mat_<double>(PATCH_SIZE, PATCH_SIZE);
+    cv::Mat patch_plus          = cv::Mat_<double>(PATCH_SIZE, PATCH_SIZE);
+    cv::Mat patch_minus         = cv::Mat_<double>(PATCH_SIZE, PATCH_SIZE);
+
+    //> get the patches on the two sides of the edge
+    get_patch_on_one_edge_side( shifted_points.first,  target_edge(2), patch_coord_x_plus,  patch_coord_y_plus,  patch_plus,  gray_img );
+    get_patch_on_one_edge_side( shifted_points.second, target_edge(2), patch_coord_x_minus, patch_coord_y_minus, patch_minus, gray_img );
+
+    std::cout << "Shifted point (+) location: (" << shifted_points.first.x << ", " << shifted_points.first.y << ")" << std::endl;
+    std::cout << "Patch (+) coordinates: " << std::endl;
+    std::cout << patch_coord_x_plus << std::endl;
+    std::cout << patch_coord_y_plus << std::endl;
+
+    std::cout << "Shifted point (-) location: (" << shifted_points.second.x << ", " << shifted_points.second.y << ")" << std::endl;
+    std::cout << "Patch (-) coordinates: " << std::endl;
+    std::cout << patch_coord_x_minus << std::endl;
+    std::cout << patch_coord_y_minus << std::endl;
+
+    if (patch_plus.type() != CV_32F) {
+        patch_plus.convertTo(patch_plus, CV_32F);
+    }
+    if (patch_minus.type() != CV_32F) {
+        patch_minus.convertTo(patch_minus, CV_32F);
+    }
+
+    //> compare the patches to get NCC scores
+}
+


### PR DESCRIPTION
Applying Lowe's ratio test for multiple validated edge hypotheses as an additional filter to increase the precision rate while maintaining high recall rate. Also link the code with the OpenCV libs to enable the attempt to use SIFT descriptors on edges as an another filter. Additional stuff to do is to resolve the segmentation fault from the SIFT filter and add NCC.