### PR TITLE
Add and fix extracting SIFT feature descriptors from edge keypoints

### DIFF
--- a/Edge_Reconst/EdgeSketch_Core.hpp
+++ b/Edge_Reconst/EdgeSketch_Core.hpp
@@ -74,15 +74,11 @@ public:
     int num_of_correct_edges_after_lowe, num_of_wrong_edges_after_lowe;
 
     //> SIFT
-    cv::Ptr<cv::SIFT> sift_detector;
+    int countUniqueClusters(const Eigen::MatrixXd& edges, double tolerance = 1e-6);
     std::vector<int> filterEdgesWithSIFT(const Eigen::MatrixXd& Edges_HYPO1_final,
-                                        const Eigen::MatrixXd& Edges_HYPO2_final,
-                                        const cv::Mat& image1, 
-                                        const cv::Mat& image2,
-                                        const std::vector<int>& valid_cluster_indices);
-    void computeSIFTDescriptorsAtEdges(const cv::Mat& image, 
-                                      const std::vector<Eigen::Vector2d>& edge_locations, 
-                                      cv::Mat& descriptors);
+                                    const Eigen::MatrixXd& Edges_HYPO2_final,
+                                    const cv::Mat& image1, 
+                                    const cv::Mat& image2);
     
     std::vector<cv::KeyPoint> convertEdgeLocationsToKeypoints(const std::vector<Eigen::Vector2d>& edge_locations);
 

--- a/Edge_Reconst/definitions.h
+++ b/Edge_Reconst/definitions.h
@@ -11,6 +11,7 @@
 //> NCC on Edges Settings
 #define EDGE_ORTHOGONAL_SHIFT_MAG       (5)         //> in pixels
 #define PATCH_SIZE                      (7)         //> in pixels
+#define NCC_THRESH                      (0.5)
 
 //> LOWE's ratio test
 #define LOWES_RATIO_THRESHOLD           (0.6)
@@ -18,7 +19,7 @@
 //> SIFT
 #define ENABLE_SIFT_FILTERING           (false)
 #define SIFT_PATCH_SIZE                 (7)
-#define SIFT_DISTANCE_THRESHOLD         (100)
+#define SIFT_DISTANCE_THRESHOLD         (3)
 
 //> Print out in terminal
 #define SHOW_EDGE_SKETCH_SETTINGS       (false)

--- a/Edge_Reconst/file_reader.cpp
+++ b/Edge_Reconst/file_reader.cpp
@@ -64,7 +64,8 @@ bool file_reader::read_an_image( int file_idx, cv::Mat &grayscale_img )
   }
   if (original_img.channels() == 3) {
     cv::cvtColor(original_img, grayscale_img, cv::COLOR_BGR2GRAY);
-  }  
+  }
+  
   return true;
 }
 

--- a/Edge_Reconst/util.cpp
+++ b/Edge_Reconst/util.cpp
@@ -364,6 +364,50 @@ namespace MultiviewGeometryUtil {
         }
         return reproj_errs;
     }
+
+    std::string multiview_geometry_util::cvMat_Type(int type)
+    {
+        //> Credit: https://stackoverflow.com/questions/10167534/how-to-find-out-what-type-of-a-mat-object-is-with-mattype-in-opencv
+
+        std::string r;
+
+        uchar depth = type & CV_MAT_DEPTH_MASK;
+        uchar chans = 1 + (type >> CV_CN_SHIFT);
+
+        switch (depth)
+        {
+        case CV_8U:
+            r = "8U";
+            break;
+        case CV_8S:
+            r = "8S";
+            break;
+        case CV_16U:
+            r = "16U";
+            break;
+        case CV_16S:
+            r = "16S";
+            break;
+        case CV_32S:
+            r = "32S";
+            break;
+        case CV_32F:
+            r = "32F";
+            break;
+        case CV_64F:
+            r = "64F";
+            break;
+        default:
+            r = "User";
+            break;
+        }
+
+        r += "C";
+        r += (chans + '0');
+
+        return r;
+    }
+
 }
 
 #endif

--- a/Edge_Reconst/util.hpp
+++ b/Edge_Reconst/util.hpp
@@ -20,6 +20,8 @@
 #include <vector>
 #include <chrono>
 
+#include <opencv2/core.hpp>
+
 //> Eigen library
 #include <Eigen/Core>
 #include <Eigen/Dense>
@@ -101,6 +103,8 @@ namespace MultiviewGeometryUtil {
         double deg_to_rad( double theta ) {
             return theta * (M_PI / 180.0);
         }
+
+        std::string cvMat_Type(int type);
 
     private:
         

--- a/test/test_functions.cpp
+++ b/test/test_functions.cpp
@@ -12,6 +12,7 @@
 #include "test_include/test_alignment.hpp"
 #include "test_include/test_epipolar_correction.hpp"
 #include "test_include/test_edge_NCC.hpp"
+#include "test_include/test_edge_SIFT_desc.hpp"
 
 #include "../Edge_Reconst/definitions.h"
 #include "../Edge_Reconst/util.hpp"
@@ -20,6 +21,7 @@
 //> Select the test
 #define TEST_EPIPOLAR_CORRECTION    (false)
 #define TEST_EDGE_NCC               (true)
+#define TEST_SIFT_DESC_ON_EDGES     (true)
 #define TEST_EDGE_ORIENTATION_AVG   (false)
 #define TEST_READ_CURVELETS         (false)
 #define TEST_EDGE_ALIGNMENT         (false)
@@ -92,6 +94,10 @@ int main(int argc, char **argv) {
 
 #if TEST_EDGE_NCC
     f_TEST_NCC();
+#endif
+
+#if TEST_SIFT_DESC_ON_EDGES
+    f_TEST_SIFT_DESCP_ON_EDGES();
 #endif
 
 #if TEST_READ_CURVELETS

--- a/test/test_include/test_edge_SIFT_desc.hpp
+++ b/test/test_include/test_edge_SIFT_desc.hpp
@@ -70,20 +70,23 @@ void f_TEST_SIFT_DESCP_ON_EDGES()
     std::vector<cv::KeyPoint> edge_kpts_H1;
     edge_kpts_H1.push_back(edge_kpt_H1);
     std::vector<cv::KeyPoint> edge_kpts_H2;
+    edge_kpts_H2.push_back(edge_kpt_H1);
     edge_kpts_H2.push_back(edge_kpt_H2);
 
     sift->compute(gray_img_H1, edge_kpts_H1, descriptors_H1);
     sift->compute(gray_img_H2, edge_kpts_H2, descriptors_H2);
 
     cv::Mat normalized_desc_H1, normalized_desc_H2;
+    normalized_desc_H2 = descriptors_H2;
     cv::normalize(descriptors_H1, normalized_desc_H1, 1.0, 0.0, cv::NORM_L2); 
-    cv::normalize(descriptors_H2, normalized_desc_H2, 1.0, 0.0, cv::NORM_L2); 
+    cv::normalize(descriptors_H2.row(0), normalized_desc_H2.row(0), 1.0, 0.0, cv::NORM_L2); 
+    cv::normalize(descriptors_H2.row(1), normalized_desc_H2.row(1), 1.0, 0.0, cv::NORM_L2); 
 
     std::cout << "Normalized SIFT Descriptors" << std::endl;
     std::cout << normalized_desc_H1 << std::endl;
     std::cout << normalized_desc_H2 << std::endl;
 
-    double similarity = cv::norm(normalized_desc_H1, normalized_desc_H2, cv::NORM_L2);
-    std::cout << "Descriptor-based similarity: " << similarity << std::endl;
+    // double similarity = cv::norm(normalized_desc_H1, normalized_desc_H2, cv::NORM_L2);
+    // std::cout << "Descriptor-based similarity: " << similarity << std::endl;
 }
 

--- a/test/test_include/test_edge_SIFT_desc.hpp
+++ b/test/test_include/test_edge_SIFT_desc.hpp
@@ -1,0 +1,89 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <iostream>
+#include <iomanip>
+#include <Eigen/Core>
+#include <Eigen/Dense>
+#include <Eigen/SVD>
+#include <memory>
+#include <cmath>
+#include <random>
+#include <chrono>
+#include <opencv2/opencv.hpp>
+#include <opencv2/features2d.hpp>
+#include <opencv2/core.hpp>
+#include <opencv2/xfeatures2d.hpp>
+
+#include "../Edge_Reconst/file_reader.hpp"
+#include "../Edge_Reconst/definitions.h"
+#include "../Edge_Reconst/util.hpp"
+
+void f_TEST_SIFT_DESCP_ON_EDGES() 
+{
+    std::shared_ptr<MultiviewGeometryUtil::multiview_geometry_util> util = nullptr;
+    util = std::shared_ptr<MultiviewGeometryUtil::multiview_geometry_util>(new MultiviewGeometryUtil::multiview_geometry_util());
+
+    std::string source_dataset_folder = "/gpfs/data/bkimia/Datasets/";
+    std::string dataset_name = "ABC-NEF/";
+    std::string object_name = "00000006";
+    cv::Mat gray_img_H1, gray_img_H2;
+    const int H1_index = 25;
+    const int H2_index = 49;
+
+    file_reader data_loader(source_dataset_folder, dataset_name, object_name, 50);
+
+    //> get the GT edge pairs for testing the NCC scores
+    std::vector<std::vector<int>> GT_EdgePairs;
+    std::vector<std::pair<int, int>> gt_edge_pairs;
+    data_loader.readGT_EdgePairs( GT_EdgePairs );
+    test_getGTEdgePairsBetweenImages( H1_index, H2_index, gt_edge_pairs, GT_EdgePairs );
+    
+    //> Read the two images 
+    if (!data_loader.read_an_image( H1_index, gray_img_H1 )) exit(1);
+    if (!data_loader.read_an_image( H2_index, gray_img_H2 )) exit(1);
+
+    // if (gray_img_H1.type() != CV_64F) gray_img_H1.convertTo(gray_img_H1, CV_64F);
+    // if (gray_img_H2.type() != CV_64F) gray_img_H2.convertTo(gray_img_H2, CV_64F);
+
+    //> Read the third-order edges from the two images
+    Eigen::MatrixXd edges_H1 = data_loader.read_Edgels_Of_a_File(H1_index, 1);
+    Eigen::MatrixXd edges_H2 = data_loader.read_Edgels_Of_a_File(H2_index, 1);
+
+    //> Randomly select a GT edge pair
+    int rand_GT_edge_pair_idx = Uniform_Random_Number_Generator< int >(0, gt_edge_pairs.size()-1);
+    std::pair<int, int> edge_pair_index = gt_edge_pairs[ rand_GT_edge_pair_idx ];
+    std::cout << "Selected edge pair index = (" << edge_pair_index.first << ", " << edge_pair_index.second << ")" << std::endl;
+
+    cv::Point2d target_edge_H1(edges_H1(edge_pair_index.first, 0), edges_H1(edge_pair_index.first, 1));
+    cv::Point2d target_edge_H2(edges_H2(edge_pair_index.second, 0), edges_H2(edge_pair_index.second, 1));
+
+    std::cout << "Picked H1 edge: (" << target_edge_H1.x << ", " << target_edge_H1.y << ")" << std::endl;
+    std::cout << "Picked H2 edge: (" << target_edge_H2.x << ", " << target_edge_H2.y << ")" << std::endl;
+
+    cv::Mat descriptors_H1, descriptors_H2;
+    cv::Ptr<cv::SIFT> sift = cv::SIFT::create();
+
+    //> Convert an edge location to a KeyPoint data type
+    cv::KeyPoint edge_kpt_H1(target_edge_H1, 1.0f);
+    cv::KeyPoint edge_kpt_H2(target_edge_H2, 1.0f);
+
+    std::vector<cv::KeyPoint> edge_kpts_H1;
+    edge_kpts_H1.push_back(edge_kpt_H1);
+    std::vector<cv::KeyPoint> edge_kpts_H2;
+    edge_kpts_H2.push_back(edge_kpt_H2);
+
+    sift->compute(gray_img_H1, edge_kpts_H1, descriptors_H1);
+    sift->compute(gray_img_H2, edge_kpts_H2, descriptors_H2);
+
+    cv::Mat normalized_desc_H1, normalized_desc_H2;
+    cv::normalize(descriptors_H1, normalized_desc_H1, 1.0, 0.0, cv::NORM_L2); 
+    cv::normalize(descriptors_H2, normalized_desc_H2, 1.0, 0.0, cv::NORM_L2); 
+
+    std::cout << "Normalized SIFT Descriptors" << std::endl;
+    std::cout << normalized_desc_H1 << std::endl;
+    std::cout << normalized_desc_H2 << std::endl;
+
+    double similarity = cv::norm(normalized_desc_H1, normalized_desc_H2, cv::NORM_L2);
+    std::cout << "Descriptor-based similarity: " << similarity << std::endl;
+}
+


### PR DESCRIPTION
Some memory issue arising from SIFT feature descriptor extraction on edge keypoints are resolved. A test function is also added. However, further evaluations on applying this SIFT filter to reflect favorable precision-recall is required.