### PR TITLE
Fix an issue in evaluating TP, FP, FN in precision-recall experiments

### DIFF
--- a/3D_Edge_Sketch_Settings.yaml
+++ b/3D_Edge_Sketch_Settings.yaml
@@ -4,7 +4,7 @@
 Num_Of_OMP_Threads: 32                #> Number of CPU cores to run 3D Edge Sketch in parallel
 Init_Hypo1_View_Index: 25 #44            #> Initial hypothesis view 1 index
 Init_Hypo2_View_Index: 49 #29            #> Initial hypothesis view 2 index
-delta: 0.3                            #> edge location perturbation
+delta: 0.4                            #> edge location perturbation
 delta_theta: 15                       #> \Delta \theta: orientation threshold
 Max_Num_Of_Support_Views: 4           #> N: minimal number of validation views supporting a hypothesis edge pair
 Multi_Thresh_Init_Thresh: 1           #> third-order edge threshold for 1st round of multi-thresholding

--- a/Edge_Reconst/EdgeSketch_Core.cpp
+++ b/Edge_Reconst/EdgeSketch_Core.cpp
@@ -196,6 +196,7 @@ void EdgeSketch_Core::Run_3D_Edge_Sketch() {
     //> ======================== precision and recall related ========================
     std::vector<std::pair<int, int>> gt_pairs;
     if ( !getGTEdgePairsBetweenImages(hyp01_view_indx, hyp02_view_indx, gt_pairs) ) exit(1);
+    gt_pairs = get_Unique_GT_H1_Edge_Index_Pairs(gt_pairs);
     std::cout << "Found " << gt_pairs.size() << " GT pairs between images "<<hyp01_view_indx<<" and "<< hyp02_view_indx << std::endl;
     std::cout << "GT edge pairs indices:" << std::endl;
     

--- a/Edge_Reconst/EdgeSketch_Core.hpp
+++ b/Edge_Reconst/EdgeSketch_Core.hpp
@@ -78,7 +78,8 @@ public:
     std::vector<int> filterEdgesWithSIFT(const Eigen::MatrixXd& Edges_HYPO1_final,
                                     const Eigen::MatrixXd& Edges_HYPO2_final,
                                     const cv::Mat& image1, 
-                                    const cv::Mat& image2);
+                                    const cv::Mat& image2,
+                                    bool debug_flag = false);
     
     std::vector<cv::KeyPoint> convertEdgeLocationsToKeypoints(const std::vector<Eigen::Vector2d>& edge_locations);
 
@@ -98,6 +99,7 @@ public:
     //> precision and recall experiments
     bool getGTEdgePairsBetweenImages(int hyp01_view_indx, int hyp02_view_indx, std::vector<std::pair<int, int>>& gt_edge_pairs);
     void get_Avg_Precision_Recall_Rates();
+    void construct_3D_edges_from_ground_truth();
 
     std::unordered_map<int, int> saveBestMatchesToFile(const std::unordered_map<int, int>& hypothesis1ToBestMatch,
                            const std::unordered_map<int, int>& hypothesis2ToBestMatch,

--- a/Edge_Reconst/EdgeSketch_Core.hpp
+++ b/Edge_Reconst/EdgeSketch_Core.hpp
@@ -325,6 +325,29 @@ private:
     //> a list of validation view indices
     std::vector<int> valid_view_index;
 
+    std::vector<std::pair<int, int>> get_Unique_GT_H1_Edge_Index_Pairs(const std::vector<std::pair<int, int>>& input_vector) {
+      std::set<int> unique_first_elements;
+      std::vector<std::pair<int, int>> result_pairs;
+
+      // Collect unique first elements
+      for (const auto& p : input_vector) {
+        unique_first_elements.insert(p.first);
+      }
+
+      // Collect corresponding pairs for unique first elements
+      for (int unique_val : unique_first_elements) {
+        // Find the first occurrence of a pair with this unique_val as its first element
+        auto it = std::find_if(input_vector.begin(), input_vector.end(),
+                              [unique_val](const std::pair<int, int>& p) {
+                                  return p.first == unique_val;
+                              });
+        if (it != input_vector.end()) {
+          result_pairs.push_back(*it);
+        }
+      }
+      return result_pairs;
+    }
+
     std::ofstream V_edges_outFile;
 
     template<typename T>

--- a/Edge_Reconst/definitions.h
+++ b/Edge_Reconst/definitions.h
@@ -17,16 +17,16 @@
 #define LOWES_RATIO_THRESHOLD           (0.6)
 
 //> SIFT
-#define ENABLE_SIFT_FILTERING           (false)
-#define SIFT_PATCH_SIZE                 (7)
-#define SIFT_DISTANCE_THRESHOLD         (3)
+#define ENABLE_SIFT_FILTERING           (true)
+#define SIFT_PATCH_SIZE                 (16.0f)
+#define SIFT_SIMILARITY_THRESHOLD       (700)
 
 //> Print out in terminal
 #define SHOW_EDGE_SKETCH_SETTINGS       (false)
 
 //> hypotheses formation settings
 #define EPIP_TANGENCY_DISPL_THRESH      (3)         //> in pixels
-#define LOCATION_PERTURBATION           (0.3)         //> in pixels
+#define LOCATION_PERTURBATION           (0.4)         //> in pixels
 #define ORIENT_PERTURBATION             (0.174533)  //> in radians. 0.174533 is 10 degrees
 #define CLUSTER_DIST_THRESH             (1)         //> τc, in pixels
 #define CLUSTER_ORIENT_THRESH           (20.0)      //> in degrees
@@ -57,6 +57,7 @@
 #define SHOW_DATA_LOADING_INFO     (false)
 #define SHOW_OMP_NUM_OF_THREADS    (true)
 #define ISOLATE_DATA               (false)
+#define SIFT_DEBUG                 (false)
 
 //> Constant values (no change)
 #define PI                            (3.1415926)

--- a/Edge_Reconst/definitions.h
+++ b/Edge_Reconst/definitions.h
@@ -19,7 +19,7 @@
 //> SIFT
 #define ENABLE_SIFT_FILTERING           (true)
 #define SIFT_PATCH_SIZE                 (16.0f)
-#define SIFT_SIMILARITY_THRESHOLD       (700)
+#define SIFT_SIMILARITY_THRESHOLD       (1000)
 
 //> Print out in terminal
 #define SHOW_EDGE_SKETCH_SETTINGS       (false)

--- a/Edge_Reconst/util.hpp
+++ b/Edge_Reconst/util.hpp
@@ -66,6 +66,16 @@ namespace MultiviewGeometryUtil {
         Eigen::Vector3d findClosestVectorFromPointToLine(Eigen::Vector3d P1, Eigen::Vector3d d1, Eigen::Vector3d P2);
         double getLineVariable(Eigen::Vector3d P1, Eigen::Vector3d d1, Eigen::Vector3d P2);
         bool checkOrientationConsistency(Eigen::Vector3d source_tangent, Eigen::Vector3d target_tangent);
+
+        double get_Vector_Diff_Norm(Eigen::Vector2d vec1, Eigen::Vector2d vec2) {
+            Eigen::Vector2d vec_diff = vec1 - vec2;
+            return vec_diff.norm();
+        }
+
+        double get_Vector_Diff_Norm(Eigen::Vector3d vec1, Eigen::Vector3d vec2) {
+            Eigen::Vector3d vec_diff = vec1 - vec2;
+            return vec_diff.norm();
+        }
         
         Eigen::Vector3d linearTriangulation(int N, const std::vector<Eigen::Vector2d> pts,  \
                                                    const std::vector<Eigen::Matrix3d> & Rs, \

--- a/test/test_functions.cpp
+++ b/test/test_functions.cpp
@@ -13,6 +13,7 @@
 #include "test_include/test_epipolar_correction.hpp"
 #include "test_include/test_edge_NCC.hpp"
 #include "test_include/test_edge_SIFT_desc.hpp"
+#include "test_include/test_GT_edge_pair.hpp"
 
 #include "../Edge_Reconst/definitions.h"
 #include "../Edge_Reconst/util.hpp"
@@ -20,8 +21,9 @@
 
 //> Select the test
 #define TEST_EPIPOLAR_CORRECTION    (false)
-#define TEST_EDGE_NCC               (true)
-#define TEST_SIFT_DESC_ON_EDGES     (true)
+#define TEST_EDGE_NCC               (false)
+#define TEST_SIFT_DESC_ON_EDGES     (false)
+#define TEST_GT_EDGE_PAIR           (true)
 #define TEST_EDGE_ORIENTATION_AVG   (false)
 #define TEST_READ_CURVELETS         (false)
 #define TEST_EDGE_ALIGNMENT         (false)
@@ -98,6 +100,10 @@ int main(int argc, char **argv) {
 
 #if TEST_SIFT_DESC_ON_EDGES
     f_TEST_SIFT_DESCP_ON_EDGES();
+#endif
+
+#if TEST_GT_EDGE_PAIR
+    f_TEST_GT_EDGE_PAIR();
 #endif
 
 #if TEST_READ_CURVELETS

--- a/test/test_include/test_GT_edge_pair.hpp
+++ b/test/test_include/test_GT_edge_pair.hpp
@@ -1,0 +1,73 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <iostream>
+#include <iomanip>
+#include <Eigen/Core>
+#include <Eigen/Dense>
+#include <Eigen/SVD>
+#include <memory>
+#include <cmath>
+#include <random>
+#include <chrono>
+#include <opencv2/opencv.hpp>
+#include <opencv2/features2d.hpp>
+#include <opencv2/core.hpp>
+#include <opencv2/xfeatures2d.hpp>
+
+#include "../Edge_Reconst/file_reader.hpp"
+#include "../Edge_Reconst/definitions.h"
+#include "../Edge_Reconst/util.hpp"
+
+std::vector<std::pair<int, int>> get_Unique_GT_H1_Edge_Index_Pairs(const std::vector<std::pair<int, int>>& input_vector) {
+    std::set<int> unique_first_elements;
+    std::vector<std::pair<int, int>> result_pairs;
+
+    // Collect unique first elements
+    for (const auto& p : input_vector) {
+        unique_first_elements.insert(p.first);
+    }
+
+    // Collect corresponding pairs for unique first elements
+    for (int unique_val : unique_first_elements) {
+        // Find the first occurrence of a pair with this unique_val as its first element
+        auto it = std::find_if(input_vector.begin(), input_vector.end(),
+                               [unique_val](const std::pair<int, int>& p) {
+                                   return p.first == unique_val;
+                               });
+        if (it != input_vector.end()) {
+            result_pairs.push_back(*it);
+        }
+    }
+    return result_pairs;
+}
+
+void f_TEST_GT_EDGE_PAIR() 
+{
+    std::shared_ptr<MultiviewGeometryUtil::multiview_geometry_util> util = nullptr;
+    util = std::shared_ptr<MultiviewGeometryUtil::multiview_geometry_util>(new MultiviewGeometryUtil::multiview_geometry_util());
+
+    std::string source_dataset_folder = "/gpfs/data/bkimia/Datasets/";
+    std::string dataset_name = "ABC-NEF/";
+    std::string object_name = "00000006";
+    cv::Mat gray_img_H1, gray_img_H2;
+    const int H1_index = 25;
+    const int H2_index = 49;
+
+    file_reader data_loader(source_dataset_folder, dataset_name, object_name, 50);
+
+    //> get the GT edge pairs for testing the NCC scores
+    std::vector<std::vector<int>> GT_EdgePairs;
+    std::vector<std::pair<int, int>> gt_edge_pairs;
+    data_loader.readGT_EdgePairs( GT_EdgePairs );
+    test_getGTEdgePairsBetweenImages( H1_index, H2_index, gt_edge_pairs, GT_EdgePairs );
+    
+    std::cout << "Size of gt_edge_pairs = " << gt_edge_pairs.size() << std::endl;
+    std::vector<std::pair<int, int>> unique_GT_edge_pairs = get_Unique_GT_H1_Edge_Index_Pairs(gt_edge_pairs);
+   
+    std::cout << "Size of the unique GT H1 edge = " << unique_GT_edge_pairs.size() << std::endl;
+    for (int i = 0; i < 20; i++) {
+        std::cout << "(" << unique_GT_edge_pairs[i].first << ", " << unique_GT_edge_pairs[i].second << ")" << std::endl;
+    }
+    
+}
+

--- a/test/test_include/test_edge_SIFT_desc.hpp
+++ b/test/test_include/test_edge_SIFT_desc.hpp
@@ -64,8 +64,8 @@ void f_TEST_SIFT_DESCP_ON_EDGES()
     cv::Ptr<cv::SIFT> sift = cv::SIFT::create();
 
     //> Convert an edge location to a KeyPoint data type
-    cv::KeyPoint edge_kpt_H1(target_edge_H1, 1.0f);
-    cv::KeyPoint edge_kpt_H2(target_edge_H2, 1.0f);
+    cv::KeyPoint edge_kpt_H1(target_edge_H1, SIFT_PATCH_SIZE, util->rad_to_deg(edges_H1(edge_pair_index.first,  2)));
+    cv::KeyPoint edge_kpt_H2(target_edge_H2, SIFT_PATCH_SIZE, util->rad_to_deg(edges_H1(edge_pair_index.second, 2)));
 
     std::vector<cv::KeyPoint> edge_kpts_H1;
     edge_kpts_H1.push_back(edge_kpt_H1);


### PR DESCRIPTION
This pull request fixes a few issues:
- How TP, FP, and FN is calculated in the precision-recall experiments: the Eigen library function `isApprox` cannot be used to decide if the hypothesis edge is close to the GT edge in terms of proximity. Rather, Euclidean distance is used. 
- The GT edge pair indices are erroneous in that H1 indices are sorted but their corresponding GT H2 edge indices are not aligned. 
- The SIFT descriptor is extracted from edge `KeyPoint` by adding edge orientation to enforce the dominant orientation of the SIFT descriptor. This is useful in small baseline hypothesis image pair, but not effective at all for large baseline cases.